### PR TITLE
Update Go version references to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Goe - Modern Go Application Framework 🚀
 
 <div align="center">
-  <img src="https://img.shields.io/badge/Go-1.21+-00ADD8?style=for-the-badge&logo=go" alt="Go Version">
+  <img src="https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go" alt="Go Version">
   <img src="https://img.shields.io/badge/License-Apache_2.0-green?style=for-the-badge" alt="License">
   <img src="https://img.shields.io/badge/Status-Beta-yellow?style=for-the-badge" alt="Status">
   <!-- Consider adding other relevant badges like build status, code coverage, etc. -->

--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -4,7 +4,7 @@ This guide will walk you through installing Goe, setting up your first project, 
 
 ## ✅ Prerequisites
 
-*   **Go**: Goe requires Go version 1.21 or newer. You can download it from [golang.org](https://golang.org/dl/).
+*   **Go**: Goe requires Go version 1.24 or newer. You can download it from [golang.org](https://golang.org/dl/).
     *   To check your Go version: `go version`
 
 ## 📦 Installation

--- a/docs/17-contributing.md
+++ b/docs/17-contributing.md
@@ -26,7 +26,7 @@ Before contributing, please read our [Code of Conduct](../CODE_OF_CONDUCT.md). W
 ## Setting Up Your Development Environment
 
 1.  **Prerequisites**:
-    *   Go 1.21 or newer.
+    *   Go 1.24 or newer.
     *   Git.
     *   A GitHub account.
 


### PR DESCRIPTION
Ensures that all mentions of the Go version in documentation and badges reflect your project's requirement of Go 1.24 or newer.

The go.mod and GitHub Actions workflows already used Go 1.24. This change updates the following files:
- README.md: Updated Go version badge from 1.21+ to 1.24+.
- docs/02-getting-started.md: Updated prerequisite from Go 1.21+ to 1.24+.
- docs/17-contributing.md: Updated prerequisite from Go 1.21+ to 1.24+.