### PR TITLE
Add package docs and improve validation middleware

### DIFF
--- a/contract/doc.go
+++ b/contract/doc.go
@@ -1,0 +1,4 @@
+// Package contract defines the core interfaces that the GOE framework relies on.
+// All framework components depend on these abstractions to keep modules optional
+// and interchangeable while following Uber Fx dependency injection patterns.
+package contract

--- a/core/app/doc.go
+++ b/core/app/doc.go
@@ -1,0 +1,4 @@
+// Package app implements the concrete contract.Application used by GOE.
+// It owns the Fx container lifecycle and coordinates module registration,
+// startup, and shutdown while preserving immutability of the DI graph.
+package app

--- a/core/cache/doc.go
+++ b/core/cache/doc.go
@@ -1,0 +1,4 @@
+// Package cache provides an optional caching module that can be registered with
+// the application when required. The module exposes a CacheManager abstraction
+// so applications can swap cache backends without changing business logic.
+package cache

--- a/core/config/doc.go
+++ b/core/config/doc.go
@@ -1,0 +1,4 @@
+// Package config supplies the permanent configuration module. It loads
+// environment-driven settings that the rest of the framework consumes via the
+// contract.Config abstraction.
+package config

--- a/core/db/doc.go
+++ b/core/db/doc.go
@@ -1,0 +1,4 @@
+// Package db provides the optional SQL database module. The module exposes the
+// contract.DB abstraction and supports lifecycle-managed connections so
+// consumers can remain decoupled from specific drivers.
+package db

--- a/core/event/doc.go
+++ b/core/event/doc.go
@@ -1,0 +1,4 @@
+// Package event implements the optional eventing module that publishes and
+// consumes messages through the contract.EventManager interfaces. The module is
+// designed to be swappable while preserving a consistent lifecycle via Fx.
+package event

--- a/core/http/doc.go
+++ b/core/http/doc.go
@@ -1,0 +1,4 @@
+// Package http supplies the optional HTTP module built on Fiber. It exposes the
+// contract.HTTPKernel abstraction to register routes and middleware while
+// keeping the transport layer isolated from business logic.
+package http

--- a/core/log/doc.go
+++ b/core/log/doc.go
@@ -1,0 +1,3 @@
+// Package log contains the permanent logging module. It bridges contract.Logger
+// with zap and ensures consistent structured logging across optional modules.
+package log

--- a/core/mongodb/doc.go
+++ b/core/mongodb/doc.go
@@ -1,0 +1,4 @@
+// Package mongodb provides the optional MongoDB module. It exposes the
+// contract.MongoDB abstraction and wires lifecycle hooks to manage client
+// connections safely through Fx.
+package mongodb

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+// Package goe bootstraps applications using the GOE framework.
+// It wires the core config, logging, and dependency injection modules and
+// conditionally attaches optional modules such as HTTP, cache, database, and
+// messaging based on supplied options.
+package goe

--- a/validation/doc.go
+++ b/validation/doc.go
@@ -1,0 +1,5 @@
+// Package validation offers HTTP request validation helpers for the HTTP module.
+// It is distinct from configuration validation, which is handled through the
+// contract.ConfigValidator interface for modules. This package focuses solely on
+// request parsing and rule enforcement for inbound traffic.
+package validation

--- a/validation/middleware.go
+++ b/validation/middleware.go
@@ -7,7 +7,13 @@ import (
 	"go.oease.dev/goe/v2/contract"
 )
 
-// Config defines the config for validation middleware
+const (
+	// DefaultValidatorContextKey is the default name used to store the validator in Fiber locals.
+	DefaultValidatorContextKey = "validator"
+	validatorContextKeyKey     = "_goe_validator_context_key"
+)
+
+// Config defines the config for validation middleware.
 type Config struct {
 	// Validator instance to use
 	Validator *Validator
@@ -19,14 +25,14 @@ type Config struct {
 	ContextKey string
 }
 
-// ConfigDefault is the default config
+// ConfigDefault is the default config.
 var ConfigDefault = Config{
 	Validator:    nil,
 	ErrorHandler: defaultErrorHandler,
-	ContextKey:   "validator",
+	ContextKey:   DefaultValidatorContextKey,
 }
 
-// defaultErrorHandler handles validation errors
+// defaultErrorHandler handles validation errors.
 func defaultErrorHandler(c fiber.Ctx, err error) error {
 	// Check if it's a validation error
 	var ve Error
@@ -51,7 +57,7 @@ func defaultErrorHandler(c fiber.Ctx, err error) error {
 	})
 }
 
-// NewMiddleware New creates a new validation middleware
+// NewMiddleware creates a new validation middleware.
 func NewMiddleware(config ...Config) fiber.Handler {
 	// Set default config
 	cfg := ConfigDefault
@@ -74,19 +80,30 @@ func NewMiddleware(config ...Config) fiber.Handler {
 		cfg.Validator = New()
 	}
 
+	contextKey := cfg.ContextKey
+	if contextKey == "" {
+		contextKey = DefaultValidatorContextKey
+	}
+
 	// Return middleware handler
 	return func(c fiber.Ctx) error {
 		// Store validator in context for use in handlers
-		c.Locals(cfg.ContextKey, cfg.Validator)
+		c.Locals(contextKey, cfg.Validator)
+		c.Locals(validatorContextKeyKey, contextKey)
 
 		// Continue to next middleware
 		return c.Next()
 	}
 }
 
-// GetValidator retrieves the validator from context
+// GetValidator retrieves the validator from context.
 func GetValidator(c fiber.Ctx) *Validator {
-	if v, ok := c.Locals("validator").(*Validator); ok {
+	storedKey, ok := c.Locals(validatorContextKeyKey).(string)
+	if !ok || storedKey == "" {
+		storedKey = DefaultValidatorContextKey
+	}
+
+	if v, ok := c.Locals(storedKey).(*Validator); ok {
 		return v
 	}
 	return nil


### PR DESCRIPTION
## Summary
- add package-level GoDoc to the root and core packages to clarify module roles and optionality
- document the HTTP validation package separately from configuration validation
- stabilize validation middleware context handling with an explicit default key and safer retrieval

## Testing
- go test ./... -timeout=30s -run Test -count=1 *(hangs; interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfad5da4c83338f54689fec8a070d)