### PR TITLE
fix(job): allow JOB_REDIS_DB=0 by using non-negative validation

### DIFF
--- a/core/internal/configvalidator/config_validator.go
+++ b/core/internal/configvalidator/config_validator.go
@@ -232,6 +232,33 @@ func ValidateOneOf(options ...string) func(value any) error {
 	}
 }
 
+// ValidateNonNegativeInt validates that value is a non-negative integer (>= 0)
+func ValidateNonNegativeInt(value any) error {
+	var num int
+	switch v := value.(type) {
+	case int:
+		num = v
+	case int64:
+		num = int(v)
+	case string:
+		if v == "" {
+			return fmt.Errorf("value cannot be empty")
+		}
+		_, err := fmt.Sscanf(v, "%d", &num)
+		if err != nil {
+			return fmt.Errorf("invalid numeric format: %v", err)
+		}
+	default:
+		return fmt.Errorf("expected numeric value")
+	}
+
+	if num < 0 {
+		return fmt.Errorf("value must be non-negative")
+	}
+
+	return nil
+}
+
 // ValidatePositiveInt validates that value is a positive integer
 func ValidatePositiveInt(value any) error {
 	var num int

--- a/core/internal/configvalidator/config_validator_test.go
+++ b/core/internal/configvalidator/config_validator_test.go
@@ -19,6 +19,7 @@ func TestConfigValidator(t *testing.T) {
 	cfg.Set("VALID_EMAIL", "test@example.com")
 	cfg.Set("VALID_DRIVER", "mysql")
 	cfg.Set("VALID_POSITIVE_INT", "10")
+	cfg.Set("VALID_NON_NEGATIVE_INT", "0")
 	cfg.Set("EMPTY_STRING", "")
 	cfg.Set("INVALID_PORT", "99999")
 	cfg.Set("INVALID_HOST_PORT", "invalid")
@@ -26,6 +27,7 @@ func TestConfigValidator(t *testing.T) {
 	cfg.Set("INVALID_EMAIL", "invalid-email")
 	cfg.Set("INVALID_DRIVER", "unsupported")
 	cfg.Set("INVALID_POSITIVE_INT", "-5")
+	cfg.Set("INVALID_NON_NEGATIVE_INT", "-1")
 
 	tests := []struct {
 		name        string
@@ -137,6 +139,21 @@ func TestConfigValidator(t *testing.T) {
 			},
 			expectError: true,
 			errorString: "value must be positive",
+		},
+		{
+			name: "valid non-negative integer (zero)",
+			setupFunc: func(v *ConfigValidator) {
+				v.RequireWithValidator("VALID_NON_NEGATIVE_INT", "Valid non-negative int", ValidateNonNegativeInt)
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid non-negative integer",
+			setupFunc: func(v *ConfigValidator) {
+				v.RequireWithValidator("INVALID_NON_NEGATIVE_INT", "Invalid non-negative int", ValidateNonNegativeInt)
+			},
+			expectError: true,
+			errorString: "value must be non-negative",
 		},
 		{
 			name: "valid one of",

--- a/core/job/module.go
+++ b/core/job/module.go
@@ -108,7 +108,7 @@ func (m *Module) ValidateConfig() error {
 	}
 
 	if m.config.Has("JOB_REDIS_DB") {
-		v.Optional("JOB_REDIS_DB", "Redis database number", configvalidator.ValidatePositiveInt)
+		v.Optional("JOB_REDIS_DB", "Redis database number", configvalidator.ValidateNonNegativeInt)
 	}
 
 	if m.config.Has("JOB_REDIS_POOL_SIZE") {


### PR DESCRIPTION
Redis database 0 is the default and a valid database number. Changed JOB_REDIS_DB validation from ValidatePositiveInt (> 0) to ValidateNonNegativeInt (>= 0). Added ValidateNonNegativeInt validator and corresponding tests.

Fixes #58

Generated with [Claude Code](https://claude.ai/code)