### PR TITLE
fix(job): use background context for long-running goroutines

### DIFF
--- a/core/job/integration_test.go
+++ b/core/job/integration_test.go
@@ -458,6 +458,201 @@ func TestManagerIntegration_Health(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestManagerIntegration_ContextLifecycle verifies Issue #61 fix:
+// background goroutines must survive after the startup context expires.
+// Before the fix, runPromoter/runScheduler/workers would exit after 2 minutes
+// because they used the Fx startup context which has a StartTimeout.
+func TestManagerIntegration_ContextLifecycle(t *testing.T) {
+	cfg := getTestConfig()
+	logger := &testLogger{t: t}
+
+	manager, err := NewManager(cfg, logger)
+	require.NoError(t, err)
+
+	var processed atomic.Bool
+
+	manager.RegisterHandler("lifecycle-test", contract.JobHandlerFunc(
+		func(ctx context.Context, j contract.Job) error {
+			processed.Store(true)
+			return nil
+		},
+	))
+
+	// Simulate the Fx startup context: expires very quickly (500ms).
+	// Before the fix, all goroutines would die when this context expires.
+	startupCtx, startupCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer startupCancel()
+
+	err = manager.Start(startupCtx)
+	require.NoError(t, err)
+	defer manager.Stop(context.Background())
+
+	// Wait for the startup context to expire
+	<-startupCtx.Done()
+	time.Sleep(200 * time.Millisecond) // give goroutines a moment
+
+	// Now dispatch a job AFTER the startup context has expired.
+	// If the goroutines died with the context, this job will never be processed.
+	bgCtx := context.Background()
+	_, err = manager.Dispatch(bgCtx, &contract.JobDefinition{
+		Name:    "lifecycle-test",
+		Payload: "after-ctx-expired",
+	})
+	require.NoError(t, err)
+
+	// Wait for processing
+	time.Sleep(3 * time.Second)
+
+	assert.True(t, processed.Load(),
+		"Job dispatched after startup context expired must still be processed (Issue #61)")
+}
+
+// TestManagerIntegration_PromoterSurvivesContextExpiry specifically tests that
+// the promoter (which moves delayed jobs to the ready queue) keeps working
+// after the startup context expires.
+func TestManagerIntegration_PromoterSurvivesContextExpiry(t *testing.T) {
+	cfg := getTestConfig()
+	logger := &testLogger{t: t}
+
+	manager, err := NewManager(cfg, logger)
+	require.NoError(t, err)
+
+	var processed atomic.Bool
+
+	manager.RegisterHandler("promoter-test", contract.JobHandlerFunc(
+		func(ctx context.Context, j contract.Job) error {
+			processed.Store(true)
+			return nil
+		},
+	))
+
+	// Start with a very short-lived context
+	startupCtx, startupCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer startupCancel()
+
+	err = manager.Start(startupCtx)
+	require.NoError(t, err)
+	defer manager.Stop(context.Background())
+
+	// Wait for startup context to expire
+	<-startupCtx.Done()
+	time.Sleep(200 * time.Millisecond)
+
+	// Dispatch a delayed job AFTER the context expired.
+	// The promoter must still be alive to move it from scheduled → ready.
+	bgCtx := context.Background()
+	_, err = manager.Dispatch(bgCtx, &contract.JobDefinition{
+		Name:    "promoter-test",
+		Payload: "delayed-after-ctx",
+		Delay:   500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// Wait: delay + promoter interval + processing buffer
+	time.Sleep(4 * time.Second)
+
+	assert.True(t, processed.Load(),
+		"Delayed job must be promoted and processed even after startup context expired")
+}
+
+// TestManagerIntegration_SchedulerSurvivesContextExpiry tests that the scheduler
+// (which creates recurring jobs) keeps working after the startup context expires.
+func TestManagerIntegration_SchedulerSurvivesContextExpiry(t *testing.T) {
+	cfg := getTestConfig()
+	logger := &testLogger{t: t}
+
+	manager, err := NewManager(cfg, logger)
+	require.NoError(t, err)
+
+	var executedCount atomic.Int32
+
+	err = manager.RegisterSchedule(&contract.ScheduledJob{
+		Name:     "scheduler-lifecycle",
+		Schedule: Every(500 * time.Millisecond),
+		Handler: contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
+			executedCount.Add(1)
+			return nil
+		}),
+		Overlap: true,
+	})
+	require.NoError(t, err)
+
+	// Start with context that expires in 300ms
+	startupCtx, startupCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer startupCancel()
+
+	err = manager.Start(startupCtx)
+	require.NoError(t, err)
+	defer manager.Stop(context.Background())
+
+	// Wait for context to expire, then wait for scheduled jobs to accumulate
+	<-startupCtx.Done()
+	time.Sleep(4 * time.Second)
+
+	count := executedCount.Load()
+	assert.Greater(t, count, int32(1),
+		"Scheduler must continue creating recurring jobs after startup context expires (got %d executions)", count)
+}
+
+// TestManagerIntegration_CancelScheduledJob verifies that cancelling a scheduled
+// (delayed) job properly removes it from the scheduled sorted set in Redis.
+// Before the fix, Cancel() checked job.status after already overwriting it to
+// Cancelled, so the ZRem on the scheduled queue never executed.
+func TestManagerIntegration_CancelScheduledJob(t *testing.T) {
+	cfg := getTestConfig()
+	logger := &testLogger{t: t}
+
+	manager, err := NewManager(cfg, logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	var processed atomic.Bool
+
+	manager.RegisterHandler("cancel-scheduled", contract.JobHandlerFunc(
+		func(ctx context.Context, j contract.Job) error {
+			processed.Store(true)
+			return nil
+		},
+	))
+
+	// Dispatch with delay (goes to scheduled sorted set)
+	jobID, err := manager.Dispatch(ctx, &contract.JobDefinition{
+		Name:    "cancel-scheduled",
+		Payload: "should-not-run",
+		Delay:   2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Verify it's in the scheduled set
+	scheduledKey := manager.scheduledKey("default")
+	count, err := manager.redis.ZCard(ctx, scheduledKey).Result()
+	require.NoError(t, err)
+	assert.Greater(t, count, int64(0), "Job should be in the scheduled set")
+
+	// Cancel the job
+	err = manager.Cancel(ctx, jobID)
+	require.NoError(t, err)
+
+	// Verify it's been removed from the scheduled set
+	score, err := manager.redis.ZScore(ctx, scheduledKey, jobID).Result()
+	assert.Error(t, err, "Cancelled job should be removed from scheduled set")
+	assert.Equal(t, float64(0), score)
+
+	// Verify job status is cancelled
+	job, err := manager.Get(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, contract.JobStatusCancelled, job.Status())
+
+	// Start the manager and wait — cancelled job should not run
+	err = manager.Start(ctx)
+	require.NoError(t, err)
+	defer manager.Stop(ctx)
+
+	time.Sleep(4 * time.Second)
+	assert.False(t, processed.Load(), "Cancelled scheduled job must not be processed")
+}
+
 func TestJobBuilder(t *testing.T) {
 	// Test fluent builder
 	job := NewJob("test-job", map[string]string{"key": "value"}).

--- a/core/job/integration_test.go
+++ b/core/job/integration_test.go
@@ -4,6 +4,7 @@ package job
 
 import (
 	"context"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,16 +17,35 @@ import (
 )
 
 // Run with: go test -tags=integration -v ./core/job/...
+//
+// Override Redis address via environment variable:
+//   TEST_REDIS_ADDR=localhost:32769 go test -tags=integration -v ./core/job/...
 
 func getTestConfig() *Config {
 	cfg := DefaultConfig()
-	cfg.RedisHosts = []string{"localhost:32768"} // Docker mapped port
-	cfg.RedisDB = 15                             // Use a separate DB for tests
+	addr := "localhost:32768" // default: Docker-mapped Redis
+	if env := os.Getenv("TEST_REDIS_ADDR"); env != "" {
+		addr = env
+	}
+	cfg.RedisHosts = []string{addr}
+	cfg.RedisDB = 15 // Use a separate DB for tests
 	cfg.KeyPrefix = "goe:job:test:"
 	cfg.Concurrency = 2
 	cfg.PollInterval = 100 * time.Millisecond
 	cfg.SchedulerInterval = 100 * time.Millisecond
 	return cfg
+}
+
+// newTestManager creates a Manager and flushes stale test keys so tests are isolated.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	cfg := getTestConfig()
+	logger := &testLogger{t: t}
+	manager, err := NewManager(cfg, logger)
+	require.NoError(t, err)
+	// Flush stale test keys for this DB
+	manager.redis.FlushDB(context.Background())
+	return manager
 }
 
 type testLogger struct {
@@ -54,11 +74,7 @@ func (l *testLogger) WithError(err error) contract.Logger             { return l
 func (l *testLogger) GetLogger() *zap.SugaredLogger                   { return nil }
 
 func TestManagerIntegration_DispatchAndProcess(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -77,7 +93,7 @@ func TestManagerIntegration_DispatchAndProcess(t *testing.T) {
 	))
 
 	// Start manager
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -113,11 +129,7 @@ func TestManagerIntegration_DispatchAndProcess(t *testing.T) {
 }
 
 func TestManagerIntegration_DelayedJob(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -133,7 +145,7 @@ func TestManagerIntegration_DelayedJob(t *testing.T) {
 		},
 	))
 
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -159,12 +171,8 @@ func TestManagerIntegration_DelayedJob(t *testing.T) {
 }
 
 func TestManagerIntegration_Retry(t *testing.T) {
-	cfg := getTestConfig()
-	cfg.RetryBackoff = 100 * time.Millisecond // Short backoff for testing
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
+	manager.config.RetryBackoff = 100 * time.Millisecond // Short backoff for testing
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -181,7 +189,7 @@ func TestManagerIntegration_Retry(t *testing.T) {
 		},
 	))
 
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -205,11 +213,7 @@ func TestManagerIntegration_Retry(t *testing.T) {
 }
 
 func TestManagerIntegration_UniqueJob(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -224,7 +228,7 @@ func TestManagerIntegration_UniqueJob(t *testing.T) {
 		},
 	))
 
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -254,11 +258,7 @@ func TestManagerIntegration_UniqueJob(t *testing.T) {
 }
 
 func TestManagerIntegration_MultipleQueues(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -277,7 +277,7 @@ func TestManagerIntegration_MultipleQueues(t *testing.T) {
 		},
 	))
 
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -307,11 +307,7 @@ func TestManagerIntegration_MultipleQueues(t *testing.T) {
 }
 
 func TestManagerIntegration_ScheduledJob(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -320,7 +316,7 @@ func TestManagerIntegration_ScheduledJob(t *testing.T) {
 	var executionTime time.Time
 
 	// Register scheduled job that runs every second
-	err = manager.RegisterSchedule(&contract.ScheduledJob{
+	err := manager.RegisterSchedule(&contract.ScheduledJob{
 		Name:     "scheduled-test",
 		Schedule: Every(1 * time.Second),
 		Handler: contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
@@ -350,11 +346,7 @@ func TestManagerIntegration_ScheduledJob(t *testing.T) {
 }
 
 func TestManagerIntegration_Stats(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -366,7 +358,7 @@ func TestManagerIntegration_Stats(t *testing.T) {
 		},
 	))
 
-	err = manager.Start(ctx)
+	err := manager.Start(ctx)
 	require.NoError(t, err)
 	defer manager.Stop(ctx)
 
@@ -392,11 +384,7 @@ func TestManagerIntegration_Stats(t *testing.T) {
 }
 
 func TestManagerIntegration_CancelJob(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -441,16 +429,12 @@ func TestManagerIntegration_CancelJob(t *testing.T) {
 }
 
 func TestManagerIntegration_Health(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx := context.Background()
 
 	// Health check should pass
-	err = manager.Health(ctx)
+	err := manager.Health(ctx)
 	assert.NoError(t, err)
 
 	// Stop and verify cleanup
@@ -463,11 +447,7 @@ func TestManagerIntegration_Health(t *testing.T) {
 // Before the fix, runPromoter/runScheduler/workers would exit after 2 minutes
 // because they used the Fx startup context which has a StartTimeout.
 func TestManagerIntegration_ContextLifecycle(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	var processed atomic.Bool
 
@@ -483,7 +463,7 @@ func TestManagerIntegration_ContextLifecycle(t *testing.T) {
 	startupCtx, startupCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer startupCancel()
 
-	err = manager.Start(startupCtx)
+	err := manager.Start(startupCtx)
 	require.NoError(t, err)
 	defer manager.Stop(context.Background())
 
@@ -511,11 +491,7 @@ func TestManagerIntegration_ContextLifecycle(t *testing.T) {
 // the promoter (which moves delayed jobs to the ready queue) keeps working
 // after the startup context expires.
 func TestManagerIntegration_PromoterSurvivesContextExpiry(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	var processed atomic.Bool
 
@@ -530,7 +506,7 @@ func TestManagerIntegration_PromoterSurvivesContextExpiry(t *testing.T) {
 	startupCtx, startupCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer startupCancel()
 
-	err = manager.Start(startupCtx)
+	err := manager.Start(startupCtx)
 	require.NoError(t, err)
 	defer manager.Stop(context.Background())
 
@@ -558,15 +534,11 @@ func TestManagerIntegration_PromoterSurvivesContextExpiry(t *testing.T) {
 // TestManagerIntegration_SchedulerSurvivesContextExpiry tests that the scheduler
 // (which creates recurring jobs) keeps working after the startup context expires.
 func TestManagerIntegration_SchedulerSurvivesContextExpiry(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	var executedCount atomic.Int32
 
-	err = manager.RegisterSchedule(&contract.ScheduledJob{
+	err := manager.RegisterSchedule(&contract.ScheduledJob{
 		Name:     "scheduler-lifecycle",
 		Schedule: Every(500 * time.Millisecond),
 		Handler: contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
@@ -599,11 +571,7 @@ func TestManagerIntegration_SchedulerSurvivesContextExpiry(t *testing.T) {
 // Before the fix, Cancel() checked job.status after already overwriting it to
 // Cancelled, so the ZRem on the scheduled queue never executed.
 func TestManagerIntegration_CancelScheduledJob(t *testing.T) {
-	cfg := getTestConfig()
-	logger := &testLogger{t: t}
-
-	manager, err := NewManager(cfg, logger)
-	require.NoError(t, err)
+	manager := newTestManager(t)
 
 	ctx := context.Background()
 
@@ -653,43 +621,5 @@ func TestManagerIntegration_CancelScheduledJob(t *testing.T) {
 	assert.False(t, processed.Load(), "Cancelled scheduled job must not be processed")
 }
 
-func TestJobBuilder(t *testing.T) {
-	// Test fluent builder
-	job := NewJob("test-job", map[string]string{"key": "value"}).
-		OnQueue("high").
-		WithDelay(5*time.Minute).
-		WithRetries(5).
-		WithTimeout(10*time.Minute).
-		Unique("unique-key").
-		WithTag("env", "test").
-		Build()
-
-	assert.Equal(t, "test-job", job.Name)
-	assert.Equal(t, "high", job.Queue)
-	assert.Equal(t, 5*time.Minute, job.Delay)
-	assert.Equal(t, 5, job.MaxAttempts)
-	assert.Equal(t, 10*time.Minute, job.Timeout)
-	assert.Equal(t, "unique-key", job.UniqueKey)
-	assert.Equal(t, "test", job.Tags["env"])
-}
-
-func TestScheduledJobBuilder(t *testing.T) {
-	handler := contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
-		return nil
-	})
-
-	sched := NewScheduledJob("cleanup").
-		Runs(DailyAt(3, 0)).
-		Handle(handler).
-		OnQueue("maintenance").
-		WithTimeout(1 * time.Hour).
-		WithRetries(2).
-		AllowOverlap().
-		Build()
-
-	assert.Equal(t, "cleanup", sched.Name)
-	assert.Equal(t, "maintenance", sched.Queue)
-	assert.Equal(t, 1*time.Hour, sched.Timeout)
-	assert.Equal(t, 2, sched.MaxAttempts)
-	assert.True(t, sched.Overlap)
-}
+// NOTE: TestJobBuilder and TestScheduledJobBuilder moved to manager_test.go
+// (pure unit tests, no Redis needed)

--- a/core/job/manager.go
+++ b/core/job/manager.go
@@ -23,6 +23,28 @@ var (
 	ErrScheduleNotFound  = errors.New("scheduled job not found")
 )
 
+// promoteScript atomically moves due jobs from the scheduled sorted set to the
+// ready list. Because ZRangeByScore + ZRem + LPush must be atomic to prevent
+// duplicate processing across multiple app instances, this is done in a Lua
+// script executed inside Redis.
+//
+// KEYS[1] = scheduled sorted-set key
+// KEYS[2] = ready list key
+// ARGV[1] = current time in milliseconds (max score)
+//
+// Returns the list of promoted job IDs.
+var promoteScript = redis.NewScript(`
+local jobs = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1], 'LIMIT', 0, 100)
+local promoted = {}
+for _, job_id in ipairs(jobs) do
+    if redis.call('ZREM', KEYS[1], job_id) == 1 then
+        redis.call('LPUSH', KEYS[2], job_id)
+        table.insert(promoted, job_id)
+    end
+end
+return promoted
+`)
+
 // Manager implements the contract.JobManager interface
 type Manager struct {
 	config  *Config
@@ -179,22 +201,24 @@ func (m *Manager) Dispatch(ctx context.Context, def *contract.JobDefinition) (st
 		def.UniqueFor = m.config.DefaultUniqueTTL
 	}
 
-	// Check uniqueness if key is provided
-	if def.UniqueKey != "" {
-		uniqueKeyRedis := m.uniqueKey(def.Queue, def.UniqueKey)
-		exists, err := m.redis.Exists(ctx, uniqueKeyRedis).Result()
-		if err != nil {
-			return "", fmt.Errorf("failed to check job uniqueness: %w", err)
-		}
-		if exists > 0 {
-			return "", ErrJobAlreadyExists
-		}
-	}
-
-	// Create job
+	// Create job first so we have the ID for the uniqueness key
 	job, err := newJob(def)
 	if err != nil {
 		return "", fmt.Errorf("failed to create job: %w", err)
+	}
+
+	// Atomically reserve uniqueness key using SetNX (atomic check-and-set).
+	// This prevents the TOCTOU race where two instances both pass an Exists
+	// check before either sets the key.
+	if def.UniqueKey != "" {
+		uniqueKeyRedis := m.uniqueKey(def.Queue, def.UniqueKey)
+		set, err := m.redis.SetNX(ctx, uniqueKeyRedis, job.id, def.UniqueFor).Result()
+		if err != nil {
+			return "", fmt.Errorf("failed to check job uniqueness: %w", err)
+		}
+		if !set {
+			return "", ErrJobAlreadyExists
+		}
 	}
 
 	// Serialize job
@@ -228,14 +252,6 @@ func (m *Manager) Dispatch(ctx context.Context, def *contract.JobDefinition) (st
 		queueKey := m.queueKey(job.queue)
 		if err := m.redis.LPush(ctx, queueKey, job.id).Err(); err != nil {
 			return "", fmt.Errorf("failed to queue job: %w", err)
-		}
-	}
-
-	// Set uniqueness key if provided
-	if def.UniqueKey != "" {
-		uniqueKeyRedis := m.uniqueKey(def.Queue, def.UniqueKey)
-		if err := m.redis.Set(ctx, uniqueKeyRedis, job.id, def.UniqueFor).Err(); err != nil {
-			m.logger.Warn("Failed to set uniqueness key", "error", err)
 		}
 	}
 
@@ -493,7 +509,10 @@ func (m *Manager) Stats(ctx context.Context) (*contract.JobStats, error) {
 	return stats, nil
 }
 
-// runScheduler runs the scheduler for recurring jobs
+// runScheduler runs the scheduler for recurring jobs.
+// In multi-instance deployments, a distributed lock ensures only one instance
+// dispatches scheduled jobs per tick. The atomic uniqueness check in Dispatch
+// serves as a second safety net against duplicate dispatches.
 func (m *Manager) runScheduler(ctx context.Context) {
 	ticker := time.NewTicker(m.config.SchedulerInterval)
 	defer ticker.Stop()
@@ -508,6 +527,17 @@ func (m *Manager) runScheduler(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
+			// Try to acquire a distributed lock for this scheduler tick.
+			// Only one instance across all replicas will win the lock.
+			// The lock auto-expires so another instance takes over if this one dies.
+			lockKey := m.config.KeyPrefix + "lock:scheduler"
+			acquired, err := m.redis.SetNX(ctx, lockKey, "1",
+				m.config.SchedulerInterval+500*time.Millisecond,
+			).Result()
+			if err != nil || !acquired {
+				continue // another instance is handling this tick
+			}
+
 			m.schedulesMu.RLock()
 			for name, sched := range m.schedules {
 				lastRun := lastRuns[name]
@@ -548,7 +578,9 @@ func (m *Manager) runScheduler(ctx context.Context) {
 	}
 }
 
-// runPromoter moves scheduled jobs to the ready queue when their time comes
+// runPromoter moves scheduled jobs to the ready queue when their time comes.
+// Uses a Lua script for atomic promote to prevent duplicate processing when
+// multiple app instances run concurrently.
 func (m *Manager) runPromoter(ctx context.Context) {
 	ticker := time.NewTicker(m.config.SchedulerInterval)
 	defer ticker.Stop()
@@ -560,37 +592,26 @@ func (m *Manager) runPromoter(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			now := time.Now().UnixMilli()
+			now := fmt.Sprintf("%d", time.Now().UnixMilli())
 
 			for _, queue := range m.totalQueues {
 				scheduledKey := m.scheduledKey(queue)
 				queueKey := m.queueKey(queue)
 
-				// Get jobs that are ready to run
-				jobs, err := m.redis.ZRangeByScore(ctx, scheduledKey, &redis.ZRangeBy{
-					Min:   "-inf",
-					Max:   fmt.Sprintf("%d", now),
-					Count: 100,
-				}).Result()
+				// Atomically: find due jobs, remove from sorted set, push to ready queue.
+				// The Lua script ensures only one instance promotes each job, even if
+				// multiple instances call ZRangeByScore at the same time.
+				result, err := promoteScript.Run(ctx, m.redis,
+					[]string{scheduledKey, queueKey}, now,
+				).StringSlice()
 
-				if err != nil {
-					m.logger.Warn("Failed to get scheduled jobs", "queue", queue, "error", err)
+				if err != nil && !errors.Is(err, redis.Nil) {
+					m.logger.Warn("Failed to promote scheduled jobs", "queue", queue, "error", err)
 					continue
 				}
 
-				for _, jobID := range jobs {
-					// Move to ready queue
-					pipe := m.redis.Pipeline()
-					pipe.ZRem(ctx, scheduledKey, jobID)
-					pipe.LPush(ctx, queueKey, jobID)
-					if _, err := pipe.Exec(ctx); err != nil {
-						m.logger.Warn("Failed to promote scheduled job",
-							"job_id", jobID,
-							"error", err,
-						)
-					}
-
-					// Update job status
+				// Update status for each promoted job
+				for _, jobID := range result {
 					job, err := m.getJobInternal(ctx, jobID)
 					if err == nil {
 						job.status = contract.JobStatusPending

--- a/core/job/manager.go
+++ b/core/job/manager.go
@@ -283,6 +283,9 @@ func (m *Manager) Cancel(ctx context.Context, jobID string) error {
 		return fmt.Errorf("cannot cancel job with status %s", job.status)
 	}
 
+	// Save original status before overwriting so we remove from the correct queue
+	originalStatus := job.status
+
 	// Update status
 	job.status = contract.JobStatusCancelled
 	job.completedAt = time.Now()
@@ -292,8 +295,8 @@ func (m *Manager) Cancel(ctx context.Context, jobID string) error {
 		return err
 	}
 
-	// Remove from queues
-	if job.status == contract.JobStatusScheduled {
+	// Remove from queues based on original status
+	if originalStatus == contract.JobStatusScheduled {
 		scheduledKey := m.scheduledKey(job.queue)
 		m.redis.ZRem(ctx, scheduledKey, jobID)
 	} else {
@@ -341,13 +344,19 @@ func (m *Manager) saveJob(ctx context.Context, job *jobImpl) error {
 }
 
 // Start starts the job workers and scheduler
-func (m *Manager) Start(ctx context.Context) error {
+func (m *Manager) Start(_ context.Context) error {
 	if m.running.Load() {
 		return nil
 	}
 
 	m.running.Store(true)
 	m.stopCh = make(chan struct{})
+
+	// Use a background context for all long-running goroutines.
+	// The Fx startup context passed here expires after StartTimeout (2 min),
+	// which would kill all background goroutines. Graceful shutdown is handled
+	// by closing stopCh in Stop().
+	bgCtx := context.Background()
 
 	// Start workers for each queue
 	m.workersMu.Lock()
@@ -358,7 +367,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			m.wg.Add(1)
 			go func(w *worker) {
 				defer m.wg.Done()
-				w.run(ctx)
+				w.run(bgCtx)
 			}(w)
 		}
 	}
@@ -367,13 +376,13 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Start scheduler if enabled
 	if m.config.SchedulerEnabled {
 		m.wg.Go(func() {
-			m.runScheduler(ctx)
+			m.runScheduler(bgCtx)
 		})
 	}
 
 	// Start scheduled job promoter
 	m.wg.Go(func() {
-		m.runPromoter(ctx)
+		m.runPromoter(bgCtx)
 	})
 
 	m.logger.Info("Job manager started",

--- a/core/job/manager_test.go
+++ b/core/job/manager_test.go
@@ -1,0 +1,476 @@
+package job
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.oease.dev/goe/v2/contract"
+	"go.uber.org/zap"
+)
+
+// nopLogger implements contract.Logger for unit tests that don't need output.
+type nopLogger struct{}
+
+func (l *nopLogger) Debug(msg string, args ...any)                   {}
+func (l *nopLogger) Info(msg string, args ...any)                    {}
+func (l *nopLogger) Warn(msg string, args ...any)                    {}
+func (l *nopLogger) Error(msg string, args ...any)                   {}
+func (l *nopLogger) Fatal(msg string, args ...any)                   {}
+func (l *nopLogger) Debugf(template string, args ...any)             {}
+func (l *nopLogger) Infof(template string, args ...any)              {}
+func (l *nopLogger) Warnf(template string, args ...any)              {}
+func (l *nopLogger) Errorf(template string, args ...any)             {}
+func (l *nopLogger) Fatalf(template string, args ...any)             {}
+func (l *nopLogger) Panicf(template string, args ...any)             {}
+func (l *nopLogger) Debugw(msg string, keysAndValues ...any)         {}
+func (l *nopLogger) Infow(msg string, keysAndValues ...any)          {}
+func (l *nopLogger) Warnw(msg string, keysAndValues ...any)          {}
+func (l *nopLogger) Errorw(msg string, keysAndValues ...any)         {}
+func (l *nopLogger) Fatalw(msg string, keysAndValues ...any)         {}
+func (l *nopLogger) With(keysAndValues ...any) contract.Logger       { return l }
+func (l *nopLogger) WithContext(ctx context.Context) contract.Logger { return l }
+func (l *nopLogger) WithError(err error) contract.Logger             { return l }
+func (l *nopLogger) GetLogger() *zap.SugaredLogger                  { return nil }
+
+func TestNewJob(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		j, err := newJob(&contract.JobDefinition{
+			Name:    "test",
+			Payload: "data",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, j.id)
+		assert.Equal(t, "test", j.name)
+		assert.Equal(t, "default", j.queue)
+		assert.Equal(t, contract.JobStatusPending, j.status)
+		assert.Equal(t, 3, j.maxAttempts)
+		assert.Equal(t, 30*time.Minute, j.timeout)
+	})
+
+	t.Run("with delay sets scheduled status", func(t *testing.T) {
+		before := time.Now()
+		j, err := newJob(&contract.JobDefinition{
+			Name:  "test",
+			Delay: 5 * time.Minute,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, contract.JobStatusScheduled, j.status)
+		assert.True(t, j.scheduledAt.After(before.Add(4*time.Minute)))
+	})
+
+	t.Run("with scheduled_at", func(t *testing.T) {
+		target := time.Now().Add(time.Hour)
+		j, err := newJob(&contract.JobDefinition{
+			Name:        "test",
+			ScheduledAt: target,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, contract.JobStatusScheduled, j.status)
+		assert.Equal(t, target, j.scheduledAt)
+	})
+
+	t.Run("custom queue and attempts", func(t *testing.T) {
+		j, err := newJob(&contract.JobDefinition{
+			Name:        "test",
+			Queue:       "high",
+			MaxAttempts: 10,
+			Timeout:     time.Hour,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "high", j.queue)
+		assert.Equal(t, 10, j.maxAttempts)
+		assert.Equal(t, time.Hour, j.timeout)
+	})
+}
+
+func TestJobSerialization(t *testing.T) {
+	original, err := newJob(&contract.JobDefinition{
+		Name:      "serialize-test",
+		Payload:   map[string]string{"key": "value"},
+		Queue:     "test-queue",
+		UniqueKey: "unique-123",
+		Tags:      map[string]string{"env": "test"},
+	})
+	require.NoError(t, err)
+
+	// Serialize
+	data, err := original.toJobData()
+	require.NoError(t, err)
+	bytes, err := data.marshal()
+	require.NoError(t, err)
+
+	// Deserialize
+	parsed, err := unmarshalJobData(bytes)
+	require.NoError(t, err)
+	restored := fromJobData(parsed)
+
+	assert.Equal(t, original.id, restored.id)
+	assert.Equal(t, original.name, restored.name)
+	assert.Equal(t, original.queue, restored.queue)
+	assert.Equal(t, original.status, restored.status)
+	assert.Equal(t, original.maxAttempts, restored.maxAttempts)
+	assert.Equal(t, original.uniqueKey, restored.uniqueKey)
+	assert.Equal(t, original.tags, restored.tags)
+	assert.Equal(t, original.timeout, restored.timeout)
+}
+
+func TestWorkerBackoff(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RetryBackoff = 1 * time.Second
+	cfg.RetryBackoffFactor = 2.0
+	cfg.MaxRetryBackoff = 30 * time.Second
+
+	w := &worker{manager: &Manager{config: cfg}}
+
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 16 * time.Second},
+		{6, 30 * time.Second}, // capped at max
+		{7, 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		backoff := w.calculateBackoff(tt.attempt)
+		assert.Equal(t, tt.expected, backoff, "attempt %d", tt.attempt)
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, 5, cfg.Concurrency)
+	assert.Equal(t, "default", cfg.DefaultQueue)
+	assert.Equal(t, 3, cfg.DefaultMaxAttempts)
+	assert.Equal(t, 30*time.Minute, cfg.DefaultTimeout)
+	assert.Equal(t, time.Second, cfg.RetryBackoff)
+	assert.Equal(t, 2.0, cfg.RetryBackoffFactor)
+	assert.Equal(t, 5*time.Minute, cfg.MaxRetryBackoff)
+	assert.True(t, cfg.SchedulerEnabled)
+	assert.True(t, cfg.DLQEnabled)
+	assert.Equal(t, 7*24*time.Hour, cfg.DLQTTL)
+}
+
+func TestManagerStartIdempotent(t *testing.T) {
+	// Verify calling Start twice returns nil (idempotent guard)
+	m := &Manager{
+		config:      DefaultConfig(),
+		totalQueues: []string{"default"},
+		stopCh:      make(chan struct{}),
+		stats:       &managerStats{queueStats: make(map[string]*queueStatsInternal)},
+	}
+	m.running.Store(true)
+
+	err := m.Start(context.Background())
+	assert.NoError(t, err) // should be no-op
+}
+
+func TestRedisKeyHelpers(t *testing.T) {
+	m := &Manager{config: &Config{KeyPrefix: "goe:job:"}}
+
+	assert.Equal(t, "goe:job:data:abc-123", m.jobKey("abc-123"))
+	assert.Equal(t, "goe:job:queue:default", m.queueKey("default"))
+	assert.Equal(t, "goe:job:scheduled:high", m.scheduledKey("high"))
+	assert.Equal(t, "goe:job:unique:default:my-key", m.uniqueKey("default", "my-key"))
+	assert.Equal(t, "goe:job:processing:default", m.processingKey("default"))
+	assert.Equal(t, "goe:job:dlq:default", m.dlqKey("default"))
+}
+
+func TestTrackQueueDeduplication(t *testing.T) {
+	m := &Manager{
+		config:      DefaultConfig(),
+		totalQueues: []string{"default"},
+		stats:       &managerStats{queueStats: make(map[string]*queueStatsInternal)},
+	}
+
+	// Track same queue twice — should not duplicate
+	m.trackQueue("default")
+	m.trackQueue("default")
+	assert.Len(t, m.totalQueues, 1)
+
+	// Track new queue — should add
+	m.trackQueue("high")
+	assert.Len(t, m.totalQueues, 2)
+	assert.Contains(t, m.totalQueues, "high")
+}
+
+func TestGetHandlerFallbackToSchedule(t *testing.T) {
+	handler := contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
+		return nil
+	})
+
+	m := &Manager{
+		logger:    &nopLogger{},
+		handlers:  make(map[string]contract.JobHandler),
+		schedules: make(map[string]*contract.ScheduledJob),
+	}
+
+	// No handler registered — should return false
+	_, ok := m.getHandler("unknown")
+	assert.False(t, ok)
+
+	// Register via schedule
+	m.schedules["scheduled-job"] = &contract.ScheduledJob{
+		Name:    "scheduled-job",
+		Handler: handler,
+	}
+	h, ok := m.getHandler("scheduled-job")
+	assert.True(t, ok)
+	assert.NotNil(t, h)
+
+	// Direct handler takes precedence over schedule handler
+	m.handlers["scheduled-job"] = handler
+	h2, ok := m.getHandler("scheduled-job")
+	assert.True(t, ok)
+	assert.NotNil(t, h2)
+}
+
+func TestRecordCompletion(t *testing.T) {
+	m := &Manager{
+		stats: &managerStats{queueStats: make(map[string]*queueStatsInternal)},
+	}
+
+	m.recordCompletion("default", true)
+	m.recordCompletion("default", true)
+	m.recordCompletion("default", false)
+
+	assert.Equal(t, int64(3), m.stats.processed.Load())
+	assert.Equal(t, int64(2), m.stats.completed.Load())
+	assert.Equal(t, int64(1), m.stats.failed.Load())
+
+	// Verify per-queue stats were auto-created
+	qs, ok := m.stats.queueStats["default"]
+	assert.True(t, ok)
+	assert.Equal(t, int64(2), qs.completed.Load())
+	assert.Equal(t, int64(1), qs.failed.Load())
+}
+
+func TestRegisterScheduleValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	m := &Manager{
+		config:    cfg,
+		logger:    &nopLogger{},
+		schedules: make(map[string]*contract.ScheduledJob),
+	}
+
+	handler := contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
+		return nil
+	})
+
+	// First registration succeeds
+	err := m.RegisterSchedule(&contract.ScheduledJob{
+		Name:     "job1",
+		Schedule: Every(time.Minute),
+		Handler:  handler,
+	})
+	assert.NoError(t, err)
+
+	// Duplicate registration fails
+	err = m.RegisterSchedule(&contract.ScheduledJob{
+		Name:     "job1",
+		Schedule: Every(time.Minute),
+		Handler:  handler,
+	})
+	assert.ErrorIs(t, err, ErrScheduleExists)
+
+	// Defaults applied
+	sched := m.schedules["job1"]
+	assert.Equal(t, cfg.DefaultQueue, sched.Queue)
+	assert.Equal(t, cfg.DefaultTimeout, sched.Timeout)
+	assert.Equal(t, cfg.DefaultMaxAttempts, sched.MaxAttempts)
+}
+
+func TestUnregisterSchedule(t *testing.T) {
+	m := &Manager{
+		config:    DefaultConfig(),
+		logger:    &nopLogger{},
+		schedules: make(map[string]*contract.ScheduledJob),
+	}
+
+	handler := contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
+		return nil
+	})
+
+	_ = m.RegisterSchedule(&contract.ScheduledJob{
+		Name:     "job1",
+		Schedule: Every(time.Minute),
+		Handler:  handler,
+	})
+
+	err := m.UnregisterSchedule("job1")
+	assert.NoError(t, err)
+
+	err = m.UnregisterSchedule("nonexistent")
+	assert.ErrorIs(t, err, ErrScheduleNotFound)
+}
+
+func TestJobImplAccessors(t *testing.T) {
+	now := time.Now()
+	j := &jobImpl{
+		id:          "test-id",
+		name:        "test-name",
+		queue:       "test-queue",
+		payload:     "test-payload",
+		status:      contract.JobStatusRunning,
+		attempts:    2,
+		maxAttempts: 5,
+		createdAt:   now,
+		scheduledAt: now,
+		startedAt:   now,
+		completedAt: now,
+		lastError:   "some error",
+		ctx:         context.Background(),
+		tags:        map[string]string{"env": "test"},
+		timeout:     time.Minute,
+		uniqueKey:   "unique-key",
+	}
+
+	assert.Equal(t, "test-id", j.ID())
+	assert.Equal(t, "test-name", j.Name())
+	assert.Equal(t, "test-queue", j.Queue())
+	assert.Equal(t, "test-payload", j.Payload())
+	assert.Equal(t, contract.JobStatusRunning, j.Status())
+	assert.Equal(t, 2, j.Attempts())
+	assert.Equal(t, 5, j.MaxAttempts())
+	assert.Equal(t, now, j.CreatedAt())
+	assert.Equal(t, now, j.ScheduledAt())
+	assert.Equal(t, now, j.StartedAt())
+	assert.Equal(t, now, j.CompletedAt())
+	assert.Equal(t, "some error", j.LastError())
+	assert.NotNil(t, j.Context())
+	assert.Equal(t, map[string]string{"env": "test"}, j.Tags())
+	assert.Equal(t, time.Minute, j.Timeout())
+	assert.Equal(t, "unique-key", j.UniqueKey())
+}
+
+func TestJobBuilderFull(t *testing.T) {
+	def := NewJob("send-email", "payload").
+		OnQueue("emails").
+		WithDelay(5 * time.Minute).
+		WithRetries(5).
+		WithTimeout(10 * time.Minute).
+		Unique("email-123").
+		UniqueFor("email-123", 2*time.Hour).
+		WithTag("env", "prod").
+		WithTags(map[string]string{"env": "prod", "priority": "high"}).
+		Build()
+
+	assert.Equal(t, "send-email", def.Name)
+	assert.Equal(t, "emails", def.Queue)
+	assert.Equal(t, 5*time.Minute, def.Delay)
+	assert.Equal(t, 5, def.MaxAttempts)
+	assert.Equal(t, 10*time.Minute, def.Timeout)
+	assert.Equal(t, "email-123", def.UniqueKey)
+	assert.Equal(t, 2*time.Hour, def.UniqueFor)
+	assert.Equal(t, "prod", def.Tags["env"])
+	assert.Equal(t, "high", def.Tags["priority"])
+}
+
+func TestJobBuilderTimeHelpers(t *testing.T) {
+	t.Run("In alias", func(t *testing.T) {
+		def := NewJob("test", nil).In(3 * time.Minute).Build()
+		assert.Equal(t, 3*time.Minute, def.Delay)
+	})
+
+	t.Run("InMinutes", func(t *testing.T) {
+		def := NewJob("test", nil).InMinutes(10).Build()
+		assert.Equal(t, 10*time.Minute, def.Delay)
+	})
+
+	t.Run("InHours", func(t *testing.T) {
+		def := NewJob("test", nil).InHours(2).Build()
+		assert.Equal(t, 2*time.Hour, def.Delay)
+	})
+
+	t.Run("Tomorrow", func(t *testing.T) {
+		def := NewJob("test", nil).Tomorrow().Build()
+		assert.Equal(t, 24*time.Hour, def.Delay)
+	})
+
+	t.Run("At", func(t *testing.T) {
+		target := time.Now().Add(time.Hour)
+		def := NewJob("test", nil).At(target).Build()
+		assert.Equal(t, target, def.ScheduledAt)
+	})
+}
+
+func TestDispatchHelpers(t *testing.T) {
+	t.Run("Dispatch", func(t *testing.T) {
+		def := Dispatch("test", "data").Build()
+		assert.Equal(t, "test", def.Name)
+		assert.Equal(t, "data", def.Payload)
+	})
+
+	t.Run("Later", func(t *testing.T) {
+		def := Later("test", "data", 5*time.Minute).Build()
+		assert.Equal(t, "test", def.Name)
+		assert.Equal(t, 5*time.Minute, def.Delay)
+	})
+
+	t.Run("AtTime", func(t *testing.T) {
+		target := time.Now().Add(time.Hour)
+		def := AtTime("test", "data", target).Build()
+		assert.Equal(t, target, def.ScheduledAt)
+	})
+}
+
+func TestScheduledJobBuilder(t *testing.T) {
+	handler := contract.JobHandlerFunc(func(ctx context.Context, j contract.Job) error {
+		return nil
+	})
+
+	t.Run("full builder", func(t *testing.T) {
+		sched := NewScheduledJob("cleanup").
+			Runs(DailyAt(3, 0)).
+			Handle(handler).
+			OnQueue("maintenance").
+			WithPayload("test-payload").
+			WithTimeout(1 * time.Hour).
+			WithRetries(2).
+			AllowOverlap().
+			WithTag("env", "prod").
+			Build()
+
+		assert.Equal(t, "cleanup", sched.Name)
+		assert.Equal(t, "maintenance", sched.Queue)
+		assert.Equal(t, "test-payload", sched.Payload)
+		assert.Equal(t, time.Hour, sched.Timeout)
+		assert.Equal(t, 2, sched.MaxAttempts)
+		assert.True(t, sched.Overlap)
+		assert.Equal(t, "prod", sched.Tags["env"])
+	})
+
+	t.Run("Using alias", func(t *testing.T) {
+		sched := NewScheduledJob("test").
+			Using(Every(time.Minute)).
+			HandleFunc(handler).
+			Build()
+		assert.NotNil(t, sched.Schedule)
+		assert.NotNil(t, sched.Handler)
+	})
+
+	t.Run("PreventOverlap", func(t *testing.T) {
+		sched := NewScheduledJob("test").
+			AllowOverlap().
+			PreventOverlap().
+			Build()
+		assert.False(t, sched.Overlap)
+	})
+}
+
+func TestStopIdempotent(t *testing.T) {
+	m := &Manager{
+		config: DefaultConfig(),
+		stopCh: make(chan struct{}),
+	}
+	// Not running — Stop should be no-op
+	err := m.Stop(context.Background())
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Comprehensive production-readiness fixes for the job module, addressing Issue #61 and additional multi-instance race conditions found during audit.

Closes #61

### Commit 1: Context lifecycle fix
- **Background goroutine context** — `Start()` was passing the Fx startup context (2min timeout) to all goroutines. Workers, scheduler, and promoter all died after 2 minutes. Fixed by using `context.Background()` — shutdown is handled by `stopCh`.
- **Cancel queue cleanup** — `Cancel()` checked `job.status` after already overwriting it to `Cancelled`, so scheduled jobs were never removed from the Redis sorted set. Fixed by saving `originalStatus` before overwriting.

### Commit 2: Multi-instance safety
- **Atomic dispatch uniqueness** — Replaced `Exists()` + `Set()` (TOCTOU race) with `SetNX()`. Two instances could previously both pass the Exists check before either set the key, creating duplicate jobs.
- **Atomic promotion (Lua script)** — Replaced non-atomic `ZRangeByScore` + pipeline(`ZRem`, `LPush`) with a Lua script. Previously if two instances read the same due jobs, `ZRem` returned 0 for one but `LPush` still executed, causing duplicate job processing.
- **Scheduler distributed lock** — Added `SetNX`-based lock so only one instance fires cron jobs per tick. The atomic dispatch uniqueness serves as a second safety net.

### Commit 3: Integration test improvements
- Added `newTestManager()` helper with DB flush for test isolation
- Made Redis address configurable via `TEST_REDIS_ADDR` env var
- Removed duplicate builder tests (moved to unit test file)

## Test Results

| Backend | Integration | Unit | Total | Result |
|---------|------------|------|-------|--------|
| Redis 7 | 13 | 38 | 51 | **ALL PASS** |
| Dragonfly | 13 | 38 | 51 | **ALL PASS** |

## Test plan

- [x] Dispatch & process immediate jobs
- [x] Delayed jobs (promoter scheduled → ready)
- [x] Retry with exponential backoff
- [x] Unique job deduplication (atomic SetNX)
- [x] Multiple queues
- [x] Cron/scheduled jobs with distributed lock
- [x] Stats collection
- [x] Cancel pending + scheduled jobs (proper Redis cleanup)
- [x] Health checks
- [x] Context lifecycle: goroutines survive startup context expiry
- [x] Promoter survives context expiry
- [x] Scheduler survives context expiry
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Dragonfly compatibility verified