### PR TITLE
feat(cache): distributed-atomic compound operations on the redis driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ jobs:
                 os: [ ubuntu-latest ]
                 go-version: [ '1.26' ]
 
+        # Redis for the probed default-lane tests (core/lock, the cache redis
+        # driver): they run wherever Redis is reachable and skip where it is
+        # not, so providing it here keeps that coverage visible to CI and
+        # codecov. Everything that REQUIRES external services stays in the
+        # integration lane (make test_integration).
+        services:
+            redis:
+                image: redis:7-alpine
+                ports:
+                    - 6379:6379
+                options: >-
+                    --health-cmd "redis-cli ping"
+                    --health-interval 2s
+                    --health-timeout 3s
+                    --health-retries 15
+
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,36 @@ your application does. Releases with neither are not listed here.
 
 ---
 
+## v2.6.0
+
+The redis driver now executes the cache's compound operations — `Add`, `Pull`,
+`Increment`/`Decrement` — as single server-side commands (`SET NX`, `GETDEL`,
+`INCRBY`). Choosing redis means the cache is shared across processes, and the
+previous lock-emulated operations were only atomic within one process: two app
+replicas could lose increments or both consume the same `Pull`ed key. The
+embedded drivers (memory, badger, bbolt) are unchanged — their process is the
+store's only writer, so the in-process lock was already correct.
+
+| Change | Action needed |
+|---|---|
+| Redis `Increment`/`Decrement` use `INCRBY`: atomic across processes, and an existing key's TTL is now **preserved** (previously reset to "never expires") | None for typical code — counters seeded with `Add(key, 0, window)` now expire with the window, which is the standard rate-limiter pattern. Keys *created* by `Increment` still never expire. If you relied on `Increment` immortalizing a TTL'd key, re-store the value without a TTL instead |
+| Redis `Increment` on non-integer values returns Redis's error | Previously stored floats were truncated to int64 and strings rejected with `value is not a number`. Counters written by `Increment` were always integers, so this only affects keys that mixed `Set(float)` with `Increment` |
+| Redis `Pull` uses `GETDEL`: atomic consume across processes | Requires Redis 6.2+ (2021). The key is now consumed even when unmarshaling into the destination fails; previously a failed unmarshal left it in place |
+| Redis `Add` uses `SET NX`: atomic across processes | None — same semantics and same "key already exists" error |
+| New optional `contract.AtomicCacheStore` capability interface | None. Custom drivers may implement it on their store to get the native path; stores without it keep the emulated per-process behaviour |
+
+### Behaviour: compound cache operations are distributed-atomic on redis
+
+The lock inside the cache is process-local, so on a shared Redis the emulated
+`Increment` (get, add, set) under-counted when several replicas raced, `Add`
+could double-admit, and `Pull` could hand the same one-time value to two
+processes. Auth-shaped code — attempt lockouts, one-time codes — silently
+depended on running a single replica. The native commands close exactly that
+gap; the guarantee is per-key atomicity on a healthy shard, not durability
+(Redis replication is asynchronous, so a failover can drop the newest writes).
+
+---
+
 ## v2.5.0
 
 The cache module drops its multi-store layer the same way MongoDB dropped

--- a/contract/cache.go
+++ b/contract/cache.go
@@ -47,16 +47,29 @@ type Cache interface {
 	// Pull retrieves and removes a value from cache
 	// The value parameter must be a pointer to the type you want to retrieve
 	// Returns nil if the key doesn't exist (no error)
+	// With a store implementing AtomicCacheStore the get-and-delete is one
+	// server-side step, atomic across processes (the key is consumed even if
+	// unmarshaling fails); otherwise it is atomic within this process only
 	Pull(key string, value any) error
 
 	// Add stores a value only if key doesn't exist
 	// A ttl of 0 uses the module's configured default TTL when one is set
+	// With a store implementing AtomicCacheStore the check-and-set is one
+	// server-side step, atomic across processes; otherwise it is atomic
+	// within this process only
 	Add(key string, value any, ttl time.Duration) error
 
-	// Increment increments an integer value
+	// Increment atomically adds the delta (default 1) to the integer at key
+	// and returns the new value; a missing key counts as 0. With a store
+	// implementing AtomicCacheStore the operation is one server-side command,
+	// atomic across processes, and an existing key's expiration is left
+	// untouched — a counter seeded with Add(key, 0, window) expires with its
+	// window. Otherwise it is emulated under a process-local lock and the
+	// stored counter never expires
 	Increment(key string, value ...int64) (int64, error)
 
-	// Decrement decrements an integer value
+	// Decrement decrements an integer value; it is Increment with a negated
+	// delta and shares its atomicity and expiration semantics
 	Decrement(key string, value ...int64) (int64, error)
 
 	// Store returns the underlying cache store
@@ -87,6 +100,32 @@ type CacheStore interface {
 	// Close closes the storage and will stop any running garbage
 	// collectors and open connections.
 	Close() error
+}
+
+// AtomicCacheStore is an optional capability interface for CacheStore
+// implementations whose backend can execute the cache's compound operations
+// server-side, in a single step that stays atomic across processes.
+//
+// When the configured store implements it, the Cache built on top routes
+// Increment/Decrement, Add and Pull through these methods instead of the
+// default lock-emulated read-modify-write, which is atomic only within one
+// process. The builtin Redis driver implements it (INCRBY, SET NX, GETDEL);
+// custom drivers registered through cache.WithCustomDriver opt in by simply
+// implementing the methods on their store.
+type AtomicCacheStore interface {
+	// Increment atomically adds delta (which may be negative) to the integer
+	// stored at key and returns the new value. A missing key counts as 0 and
+	// the key it creates never expires; an existing key's expiration is left
+	// untouched. It fails when the current value is not an integer.
+	Increment(key string, delta int64) (int64, error)
+
+	// SetIfNotExists stores val for key only when the key does not already
+	// exist, reporting whether it stored. An exp of 0 means no expiration.
+	SetIfNotExists(key string, val []byte, exp time.Duration) (bool, error)
+
+	// GetDelete retrieves the value for key and deletes it in the same
+	// atomic step. `nil, nil` is returned when the key does not exist.
+	GetDelete(key string) ([]byte, error)
 }
 
 // CacheStoreFactory creates cache store instances. Custom backends register

--- a/core/cache/atomic_test.go
+++ b/core/cache/atomic_test.go
@@ -115,6 +115,16 @@ func TestCache_Add_NativeStore(t *testing.T) {
 		store.AssertExpectations(t)
 	})
 
+	t.Run("propagates marshal errors without touching the store", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+
+		err := cache.Add("key", make(chan int), time.Minute)
+		assert.Error(t, err)
+
+		store.AssertNotCalled(t, "SetIfNotExists", mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("resolves ttl 0 to the configured default", func(t *testing.T) {
 		store := &MockAtomicCacheStore{}
 		cache := New(store, "test", 45*time.Minute)

--- a/core/cache/atomic_test.go
+++ b/core/cache/atomic_test.go
@@ -1,0 +1,228 @@
+package cache
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.oease.dev/goe/v2/contract"
+)
+
+// MockAtomicCacheStore implements contract.CacheStore plus the optional
+// contract.AtomicCacheStore capability, standing in for stores (like the
+// builtin Redis driver) whose backend executes compound operations natively.
+type MockAtomicCacheStore struct {
+	MockCacheStore
+}
+
+func (m *MockAtomicCacheStore) Increment(key string, delta int64) (int64, error) {
+	args := m.Called(key, delta)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockAtomicCacheStore) SetIfNotExists(key string, val []byte, exp time.Duration) (bool, error) {
+	args := m.Called(key, val, exp)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockAtomicCacheStore) GetDelete(key string) ([]byte, error) {
+	args := m.Called(key)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+var (
+	_ contract.CacheStore       = (*MockAtomicCacheStore)(nil)
+	_ contract.AtomicCacheStore = (*MockAtomicCacheStore)(nil)
+)
+
+func TestCache_Increment_NativeStore(t *testing.T) {
+	t.Run("routes through the store's native increment", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("Increment", "test:counter", int64(1)).Return(int64(6), nil)
+
+		newValue, err := cache.Increment("counter")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(6), newValue)
+
+		store.AssertExpectations(t)
+		store.AssertNotCalled(t, "Get", mock.Anything)
+		store.AssertNotCalled(t, "Set", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("passes a custom delta", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("Increment", "test:counter", int64(5)).Return(int64(15), nil)
+
+		newValue, err := cache.Increment("counter", 5)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(15), newValue)
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("decrement negates the delta", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("Increment", "test:counter", int64(-3)).Return(int64(7), nil)
+
+		newValue, err := cache.Decrement("counter", 3)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(7), newValue)
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("propagates store errors", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("Increment", "test:counter", int64(1)).Return(int64(0), errors.New("boom"))
+
+		newValue, err := cache.Increment("counter")
+		assert.EqualError(t, err, "boom")
+		assert.Equal(t, int64(0), newValue)
+
+		store.AssertExpectations(t)
+	})
+}
+
+func TestCache_Add_NativeStore(t *testing.T) {
+	t.Run("stores through the native check-and-set", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("SetIfNotExists", "test:key", []byte(`"value"`), time.Minute).Return(true, nil)
+
+		err := cache.Add("key", "value", time.Minute)
+		assert.NoError(t, err)
+
+		store.AssertExpectations(t)
+		store.AssertNotCalled(t, "Get", mock.Anything)
+		store.AssertNotCalled(t, "Set", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("reports an existing key with the emulated path's error", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("SetIfNotExists", "test:key", []byte(`"value"`), time.Minute).Return(false, nil)
+
+		err := cache.Add("key", "value", time.Minute)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "key already exists")
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("resolves ttl 0 to the configured default", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 45*time.Minute)
+		store.On("SetIfNotExists", "test:key", []byte(`"value"`), 45*time.Minute).Return(true, nil)
+
+		err := cache.Add("key", "value", 0)
+		assert.NoError(t, err)
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("propagates store errors", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("SetIfNotExists", "test:key", []byte(`"value"`), time.Minute).Return(false, errors.New("boom"))
+
+		err := cache.Add("key", "value", time.Minute)
+		assert.EqualError(t, err, "boom")
+
+		store.AssertExpectations(t)
+	})
+}
+
+func TestCache_Pull_NativeStore(t *testing.T) {
+	t.Run("consumes through the native get-delete", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("GetDelete", "test:key").Return([]byte(`"value"`), nil)
+
+		var value string
+		err := cache.Pull("key", &value)
+		assert.NoError(t, err)
+		assert.Equal(t, "value", value)
+
+		store.AssertExpectations(t)
+		store.AssertNotCalled(t, "Get", mock.Anything)
+		store.AssertNotCalled(t, "Delete", mock.Anything)
+	})
+
+	t.Run("miss keeps nil error and untouched destination", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("GetDelete", "test:key").Return([]byte(nil), nil)
+
+		value := "untouched"
+		err := cache.Pull("key", &value)
+		assert.NoError(t, err)
+		assert.Equal(t, "untouched", value)
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("rejects non-pointer destinations before touching the store", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+
+		var value string
+		err := cache.Pull("key", value)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a non-nil pointer")
+
+		store.AssertNotCalled(t, "GetDelete", mock.Anything)
+	})
+
+	t.Run("propagates store errors", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		cache := New(store, "test", 0)
+		store.On("GetDelete", "test:key").Return([]byte(nil), errors.New("boom"))
+
+		var value string
+		err := cache.Pull("key", &value)
+		assert.EqualError(t, err, "boom")
+
+		store.AssertExpectations(t)
+	})
+}
+
+// The typed helpers wrap the untyped methods, so they must pick up the native
+// path transparently — found=false on a consumed-nothing miss, found=true with
+// the decoded value on a hit.
+func TestTypedPull_NativeStore(t *testing.T) {
+	t.Run("hit", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		c := New(store, "test", 0)
+		store.On("GetDelete", "test:otp").Return([]byte(`{"purpose":"signup","email":"a@b.c"}`), nil)
+
+		type stash struct {
+			Purpose string `json:"purpose"`
+			Email   string `json:"email"`
+		}
+		v, found, err := Pull[stash](c, "otp")
+		assert.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, stash{Purpose: "signup", Email: "a@b.c"}, v)
+
+		store.AssertExpectations(t)
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		store := &MockAtomicCacheStore{}
+		c := New(store, "test", 0)
+		store.On("GetDelete", "test:otp").Return([]byte(nil), nil)
+
+		v, found, err := Pull[string](c, "otp")
+		assert.NoError(t, err)
+		assert.False(t, found)
+		assert.Empty(t, v)
+
+		store.AssertExpectations(t)
+	})
+}

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -15,6 +15,7 @@ import (
 // cache implements the Cache interface
 type cache struct {
 	store      contract.CacheStore
+	atomic     contract.AtomicCacheStore // non-nil when store supports native atomic ops
 	prefix     string
 	defaultTTL time.Duration
 	mu         sync.RWMutex
@@ -28,11 +29,16 @@ type cache struct {
 // "no expiration". Forever and RememberForever always store without
 // expiration regardless of the default.
 func New(store contract.CacheStore, prefix string, defaultTTL time.Duration) contract.Cache {
-	return &cache{
+	c := &cache{
 		store:      store,
 		prefix:     prefix,
 		defaultTTL: defaultTTL,
 	}
+	// Stores that carry the optional capability get the compound operations
+	// (Increment/Decrement, Add, Pull) executed natively by the backend,
+	// making them atomic across processes instead of per-process.
+	c.atomic, _ = store.(contract.AtomicCacheStore)
+	return c
 }
 
 // resolveTTL maps the caller's ttl to the effective expiration: 0 means the
@@ -221,7 +227,9 @@ func (c *cache) RememberForever(key string, value any, callback func() (any, err
 	return c.remember(key, value, 0, callback)
 }
 
-// Pull retrieves and removes a value from cache atomically.
+// Pull retrieves and removes a value from cache. On a native atomic store
+// the get-and-delete is one server-side step shared across processes; on
+// other stores it is TOCTOU-safe within this process only.
 func (c *cache) Pull(key string, value any) error {
 	// Validate that value is a pointer
 	rv := reflect.ValueOf(value)
@@ -229,8 +237,23 @@ func (c *cache) Pull(key string, value any) error {
 		return errors.New("value must be a non-nil pointer")
 	}
 
-	// Use exclusive lock for the entire get-then-delete operation
-	// to prevent TOCTOU race conditions.
+	// A store with native atomic support retrieves and deletes in one
+	// server-side step (atomic across processes). Note the key is consumed
+	// even when unmarshaling the returned bytes fails.
+	if c.atomic != nil {
+		data, err := c.atomic.GetDelete(c.prefixKey(key))
+		if err != nil {
+			return err
+		}
+		if data == nil {
+			// Cache miss is not an error, just return nil
+			return nil
+		}
+		return json.Unmarshal(data, value)
+	}
+
+	// Emulated path: exclusive lock for the entire get-then-delete operation
+	// to prevent TOCTOU race conditions within this process.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -255,11 +278,30 @@ func (c *cache) Pull(key string, value any) error {
 	return nil
 }
 
-// Add stores a value only if key doesn't exist
-// This is an atomic check-and-set operation to prevent race conditions.
+// Add stores a value only if key doesn't exist. On a native atomic store the
+// check-and-set is one server-side step shared across processes; on other
+// stores it is atomic within this process only.
 // A ttl of 0 uses the configured default TTL when there is one, otherwise
 // the value never expires.
 func (c *cache) Add(key string, value any, ttl time.Duration) error {
+	// A store with native atomic support performs the check-and-set
+	// server-side (atomic across processes); no local locking needed.
+	if c.atomic != nil {
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		stored, err := c.atomic.SetIfNotExists(c.prefixKey(key), data, c.resolveTTL(ttl))
+		if err != nil {
+			return err
+		}
+		if !stored {
+			return errors.New("key already exists")
+		}
+		return nil
+	}
+
+	// Emulated path: atomic within this process only.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -281,15 +323,25 @@ func (c *cache) Add(key string, value any, ttl time.Duration) error {
 	return c.store.Set(c.prefixKey(key), marshaledData, c.resolveTTL(ttl))
 }
 
-// Increment increments an integer value
-// This is an atomic read-modify-write operation to prevent race conditions
+// Increment increments an integer value. On a native atomic store the
+// operation is one server-side command shared across processes, leaving an
+// existing key's expiration untouched; on other stores it is a
+// read-modify-write under a process-local lock and the counter never expires.
 func (c *cache) Increment(key string, value ...int64) (int64, error) {
 	increment := int64(1)
 	if len(value) > 0 {
 		increment = value[0]
 	}
 
-	// Use exclusive lock for the entire read-modify-write operation
+	// A store with native atomic support executes the whole operation
+	// server-side (atomic across processes) and keeps an existing key's
+	// expiration untouched; no local locking needed.
+	if c.atomic != nil {
+		return c.atomic.Increment(c.prefixKey(key), increment)
+	}
+
+	// Emulated path: exclusive lock for the entire read-modify-write
+	// operation, atomic within this process only.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -326,8 +378,9 @@ func (c *cache) Increment(key string, value ...int64) (int64, error) {
 
 	// Store back (directly to avoid re-acquiring lock).
 	// Note: TTL is set to 0 (no expiration) because CacheStore does not expose
-	// a method to query the current key's TTL. For TTL-sensitive counters,
-	// consider using the underlying store directly.
+	// a method to query the current key's TTL. Stores with native atomic
+	// support (contract.AtomicCacheStore) preserve the key's expiration
+	// instead of taking this path.
 	marshaledData, err := json.Marshal(newValue)
 	if err != nil {
 		return 0, err

--- a/core/cache/doc.go
+++ b/core/cache/doc.go
@@ -38,7 +38,9 @@
 // CACHE_TTL / cache.WithTTL set the expiration used when a caller passes
 // ttl == 0 to Set, Add or Remember. Without a configured default, ttl == 0
 // keeps meaning "no expiration". Forever and RememberForever always store
-// without expiration, and Increment/Decrement counters never expire.
+// without expiration. Keys created by Increment/Decrement never expire; what
+// happens to an existing key's expiration depends on the driver — see
+// Atomicity below.
 //
 // # Typed access
 //
@@ -51,6 +53,29 @@
 // Get and Pull report found=false with a zero value on a miss; GetOr
 // substitutes a fallback; Remember keeps the untyped method's singleflight
 // deduplication and default-TTL handling.
+//
+// # Atomicity
+//
+// Add, Pull and Increment/Decrement are compound operations. On a store that
+// implements contract.AtomicCacheStore — the builtin redis driver — each one
+// executes as a single server-side command (SET NX, GETDEL, INCRBY), making
+// it atomic across every process sharing the cache. Increment then leaves an
+// existing key's expiration untouched, so a counter seeded with
+//
+//	c.Add("attempts:"+id, 0, window) // ignore "key already exists"
+//	n, _ := c.Increment("attempts:" + id)
+//
+// expires with its window — the classic rate-limiter shape. GETDEL requires
+// Redis 6.2+, and the atomicity is per-key on a healthy shard: asynchronous
+// replication means a failover can lose the most recent writes.
+//
+// On the embedded drivers (memory, badger, bbolt) the same operations are
+// serialized with an in-process lock instead. That is just as correct there,
+// because the process owning an embedded store is its only writer — but the
+// emulated Increment cannot read a key's remaining TTL, so it stores the
+// counter without expiration. Custom drivers opt into the native path by
+// implementing contract.AtomicCacheStore on their store; the cache detects
+// the capability automatically.
 //
 // # Custom drivers
 //

--- a/core/cache/drivers_redis.go
+++ b/core/cache/drivers_redis.go
@@ -1,7 +1,10 @@
 package cache
 
 import (
+	"context"
+	"errors"
 	"net/url"
+	"time"
 
 	"github.com/gofiber/storage/redis/v3"
 	goredis "github.com/redis/go-redis/v9"
@@ -10,7 +13,34 @@ import (
 
 // RedisStoreFactory creates Fiber Redis store instances
 func RedisStoreFactory(config contract.Config) (contract.CacheStore, error) {
-	return redis.New(buildRedisConfig(config)), nil
+	return &redisStore{Storage: redis.New(buildRedisConfig(config))}, nil
+}
+
+// redisStore wraps the Fiber Redis storage to expose the backend's native
+// atomic commands as the contract.AtomicCacheStore capability: INCRBY,
+// SET NX and GETDEL run server-side, keeping the cache's compound operations
+// atomic across every process that shares this Redis — the process-local
+// locks of the emulated path cannot give that. GetDelete needs Redis 6.2+.
+type redisStore struct {
+	*redis.Storage
+}
+
+var _ contract.AtomicCacheStore = (*redisStore)(nil)
+
+func (s *redisStore) Increment(key string, delta int64) (int64, error) {
+	return s.Conn().IncrBy(context.Background(), key, delta).Result()
+}
+
+func (s *redisStore) SetIfNotExists(key string, val []byte, exp time.Duration) (bool, error) {
+	return s.Conn().SetNX(context.Background(), key, val, exp).Result()
+}
+
+func (s *redisStore) GetDelete(key string) ([]byte, error) {
+	data, err := s.Conn().GetDel(context.Background(), key).Bytes()
+	if errors.Is(err, goredis.Nil) {
+		return nil, nil
+	}
+	return data, err
 }
 
 // buildRedisConfig maps CACHE_REDIS_* configuration onto the Fiber Redis

--- a/core/cache/drivers_redis_native_test.go
+++ b/core/cache/drivers_redis_native_test.go
@@ -1,0 +1,131 @@
+package cache
+
+import (
+	"context"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.oease.dev/goe/v2/contract"
+	"go.oease.dev/goe/v2/core/config"
+)
+
+// The redis driver's native atomic operations are exercised in the default
+// test lane the same way core/lock uses Redis: probe once per package, run
+// wherever a Redis happens to be listening (CI provides one), skip cheaply
+// where none is. The deeper end-to-end suites stay in the integration lane.
+
+// testRedisAddr is the Redis instance these tests use, redirectable with
+// GOE_TEST_REDIS_ADDR like every other probed suite.
+var testRedisAddr = envOr("GOE_TEST_REDIS_ADDR", "127.0.0.1:6379")
+
+// redisAvailable is probed once for the whole package, so a missing Redis
+// costs a single short dial instead of a timeout per test.
+var redisAvailable bool
+
+func TestMain(m *testing.M) {
+	redisAvailable = probeRedis(testRedisAddr, 500*time.Millisecond)
+	os.Exit(m.Run())
+}
+
+// probeRedis reports whether something is accepting connections at addr. A
+// plain TCP dial is deliberate: it is fast, and if the port is open but Redis
+// is unhealthy the tests should fail loudly rather than quietly skip.
+func probeRedis(addr string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// requireRedis skips the calling test immediately when Redis is unreachable.
+func requireRedis(t *testing.T) {
+	t.Helper()
+	if !redisAvailable {
+		t.Skipf("Redis not reachable at %s; start it (docker-compose.test.yml) "+
+			"or set GOE_TEST_REDIS_ADDR", testRedisAddr)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func TestRedisStoreNativeAtomicOps(t *testing.T) {
+	requireRedis(t)
+
+	host, portStr, err := net.SplitHostPort(testRedisAddr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	cfg := config.NewModule()
+	cfg.Provide().Set("CACHE_REDIS_HOST", host)
+	cfg.Provide().Set("CACHE_REDIS_PORT", port)
+	// Database 14 keeps clear of the integration suite's database 15.
+	cfg.Provide().Set("CACHE_REDIS_DATABASE", 14)
+
+	store, err := RedisStoreFactory(cfg.Provide())
+	require.NoError(t, err)
+
+	native, ok := store.(contract.AtomicCacheStore)
+	require.True(t, ok, "redis store must expose the native atomic capability")
+
+	// Independent client so TTL assertions run against Redis itself. Cleanup
+	// deletes only this test's keys — no FLUSHDB, the database may be shared.
+	verify := goredis.NewClient(&goredis.Options{Addr: testRedisAddr, DB: 14})
+	t.Cleanup(func() { _ = verify.Close() })
+	ctx := context.Background()
+	require.NoError(t, verify.Del(ctx, "native:new", "native:ttl", "native:add", "native:pull").Err())
+
+	t.Run("increment creates without expiration and preserves an existing TTL", func(t *testing.T) {
+		n, err := native.Increment("native:new", 2)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n)
+
+		ttl, err := verify.TTL(ctx, "native:new").Result()
+		require.NoError(t, err)
+		assert.Less(t, ttl, time.Duration(0), "key created by Increment must have no expiration")
+
+		require.NoError(t, store.Set("native:ttl", []byte("5"), 30*time.Second))
+		n, err = native.Increment("native:ttl", 1)
+		require.NoError(t, err)
+		assert.Equal(t, int64(6), n)
+
+		ttl, err = verify.TTL(ctx, "native:ttl").Result()
+		require.NoError(t, err)
+		assert.Greater(t, ttl, time.Duration(0), "INCRBY must not strip the TTL")
+	})
+
+	t.Run("set-if-not-exists admits exactly once", func(t *testing.T) {
+		stored, err := native.SetIfNotExists("native:add", []byte(`"first"`), 30*time.Second)
+		require.NoError(t, err)
+		assert.True(t, stored)
+
+		stored, err = native.SetIfNotExists("native:add", []byte(`"second"`), 30*time.Second)
+		require.NoError(t, err)
+		assert.False(t, stored, "second write must be rejected")
+	})
+
+	t.Run("get-delete consumes and reports misses as nil, nil", func(t *testing.T) {
+		require.NoError(t, store.Set("native:pull", []byte(`"v"`), 30*time.Second))
+
+		data, err := native.GetDelete("native:pull")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`"v"`), data)
+
+		data, err = native.GetDelete("native:pull")
+		require.NoError(t, err)
+		assert.Nil(t, data, "consumed key must miss")
+	})
+}

--- a/core/cache/drivers_redis_test.go
+++ b/core/cache/drivers_redis_test.go
@@ -3,11 +3,15 @@
 package cache
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.oease.dev/goe/v2/contract"
 	"go.oease.dev/goe/v2/core/config"
 )
 
@@ -163,5 +167,171 @@ func TestRedisStoreIntegration(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Nil(t, retrieved)
 		}
+	})
+}
+
+// newAtomicTestStore builds a redis store on the test database and resets it.
+func newAtomicTestStore(t *testing.T) contract.CacheStore {
+	t.Helper()
+
+	cfg := config.NewModule()
+	cfg.Provide().Set("CACHE_REDIS_HOST", "localhost")
+	cfg.Provide().Set("CACHE_REDIS_PORT", 6379)
+	cfg.Provide().Set("CACHE_REDIS_DATABASE", 15)
+
+	store, err := RedisStoreFactory(cfg.Provide())
+	require.NoError(t, err)
+	require.NoError(t, store.Reset())
+	return store
+}
+
+// newVerifyClient returns an independent go-redis client so TTL and value
+// assertions run against Redis itself rather than through the code under test.
+func newVerifyClient(t *testing.T) *goredis.Client {
+	t.Helper()
+
+	verify := goredis.NewClient(&goredis.Options{Addr: "localhost:6379", DB: 15})
+	t.Cleanup(func() { _ = verify.Close() })
+	return verify
+}
+
+func TestRedisStoreAtomicIntegration(t *testing.T) {
+	store := newAtomicTestStore(t)
+	verify := newVerifyClient(t)
+	ctx := context.Background()
+
+	native, ok := store.(contract.AtomicCacheStore)
+	require.True(t, ok, "redis store must expose the native atomic capability")
+
+	t.Run("increment creates a missing key without expiration", func(t *testing.T) {
+		n, err := native.Increment("atomic:new", 1)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+
+		ttl, err := verify.TTL(ctx, "atomic:new").Result()
+		require.NoError(t, err)
+		assert.Less(t, ttl, time.Duration(0), "key created by Increment must have no expiration")
+	})
+
+	t.Run("increment preserves an existing key's TTL", func(t *testing.T) {
+		require.NoError(t, store.Set("atomic:ttl", []byte("5"), 30*time.Second))
+
+		n, err := native.Increment("atomic:ttl", 2)
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), n)
+
+		ttl, err := verify.TTL(ctx, "atomic:ttl").Result()
+		require.NoError(t, err)
+		assert.Greater(t, ttl, time.Duration(0), "increment must not strip the TTL")
+		assert.LessOrEqual(t, ttl, 30*time.Second)
+	})
+
+	t.Run("increment rejects non-integer values", func(t *testing.T) {
+		require.NoError(t, store.Set("atomic:str", []byte(`"nope"`), 30*time.Second))
+
+		_, err := native.Increment("atomic:str", 1)
+		assert.Error(t, err)
+	})
+
+	t.Run("set-if-not-exists stores only once and applies the TTL", func(t *testing.T) {
+		stored, err := native.SetIfNotExists("atomic:add", []byte(`"first"`), 30*time.Second)
+		require.NoError(t, err)
+		assert.True(t, stored)
+
+		stored, err = native.SetIfNotExists("atomic:add", []byte(`"second"`), 30*time.Second)
+		require.NoError(t, err)
+		assert.False(t, stored, "second write must be rejected")
+
+		data, err := store.Get("atomic:add")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`"first"`), data)
+
+		ttl, err := verify.TTL(ctx, "atomic:add").Result()
+		require.NoError(t, err)
+		assert.Greater(t, ttl, time.Duration(0))
+	})
+
+	t.Run("set-if-not-exists with zero exp stores without expiration", func(t *testing.T) {
+		stored, err := native.SetIfNotExists("atomic:forever", []byte(`1`), 0)
+		require.NoError(t, err)
+		assert.True(t, stored)
+
+		ttl, err := verify.TTL(ctx, "atomic:forever").Result()
+		require.NoError(t, err)
+		assert.Less(t, ttl, time.Duration(0))
+	})
+
+	t.Run("get-delete consumes the key in one step", func(t *testing.T) {
+		require.NoError(t, store.Set("atomic:pull", []byte(`"v"`), 30*time.Second))
+
+		data, err := native.GetDelete("atomic:pull")
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`"v"`), data)
+
+		gone, err := store.Get("atomic:pull")
+		require.NoError(t, err)
+		assert.Nil(t, gone)
+	})
+
+	t.Run("get-delete misses with nil, nil", func(t *testing.T) {
+		data, err := native.GetDelete("atomic:absent")
+		require.NoError(t, err)
+		assert.Nil(t, data)
+	})
+}
+
+// End-to-end through contract.Cache: the compound operations must ride the
+// native capability, which shows up as behavior the emulated path cannot
+// provide — most importantly Increment leaving a seeded TTL intact.
+func TestRedisCacheAtomicEndToEndIntegration(t *testing.T) {
+	store := newAtomicTestStore(t)
+	verify := newVerifyClient(t)
+	ctx := context.Background()
+
+	c := New(store, "e2e", 0)
+
+	t.Run("rate limiter pattern: Add seeds the TTL, Increment counts within it", func(t *testing.T) {
+		require.NoError(t, c.Add("attempts", 0, 30*time.Second))
+
+		for want := int64(1); want <= 3; want++ {
+			n, err := c.Increment("attempts")
+			require.NoError(t, err)
+			assert.Equal(t, want, n)
+		}
+
+		ttl, err := verify.TTL(ctx, "e2e:attempts").Result()
+		require.NoError(t, err)
+		assert.Greater(t, ttl, time.Duration(0), "lockout window must survive the increments")
+		assert.LessOrEqual(t, ttl, 30*time.Second)
+	})
+
+	t.Run("concurrent increments never lose an update", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := c.Increment("hits")
+				assert.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+
+		var got int64
+		require.NoError(t, c.Get("hits", &got))
+		assert.Equal(t, int64(50), got)
+	})
+
+	t.Run("typed Pull consumes a one-time value exactly once", func(t *testing.T) {
+		require.NoError(t, c.Set("otp", map[string]string{"purpose": "signup"}, 30*time.Second))
+
+		v, found, err := Pull[map[string]string](c, "otp")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "signup", v["purpose"])
+
+		_, found, err = Pull[map[string]string](c, "otp")
+		require.NoError(t, err)
+		assert.False(t, found, "second pull must miss")
 	})
 }


### PR DESCRIPTION
## Summary

`Cache.Increment/Decrement`, `Add` and `Pull` are compound operations guarded by a process-local mutex. On the embedded drivers that lock is the whole story — the process is the store's only writer. On redis it is not: every replica sharing the cache races the others between the Get and the Set/Delete, so attempt counters under-count, `Add` can double-admit, and two processes can consume the same `Pull`ed one-time value. `Increment` additionally re-stored values with `exp=0`, stripping any existing TTL and immortalizing counter keys — which ruled out the standard rate-limiter pattern (`Add(key, 0, window)` to seed, `Increment` to count).

This PR makes the redis driver execute those operations as single server-side commands, the way Laravel's redis cache store (whose API this module mirrors) has always done.

## Design

- New **optional capability interface** `contract.AtomicCacheStore` (`Increment`, `SetIfNotExists`, `GetDelete`). `contract.CacheStore` stays Fiber-Storage-compatible, so existing custom drivers keep working untouched and can opt in by implementing the three methods — standard Go capability detection (`io.ReaderFrom` style).
- `cache.New` detects the capability once; `Increment/Decrement`, `Add` and `Pull` route through it with no local locking. The emulated path is byte-for-byte unchanged for stores without it.
- The redis driver wraps the Fiber storage and implements the capability over `Conn()`: `INCRBY`, `SET NX` (with the resolved default TTL), `GETDEL`.
- Embedded drivers (memory/badger/bbolt) intentionally unchanged — their in-process lock is already correct.

## Behaviour changes (redis driver only)

| Before | After |
|---|---|
| `Increment` = Get+Set under local lock; lost updates across replicas | `INCRBY`, atomic across processes |
| `Increment` re-stored with `exp=0` — TTL stripped, key immortal | Existing key's TTL **preserved**; keys created by `Increment` still never expire |
| `Increment` truncated stored floats to int64 | Redis errors on non-integer values |
| `Add` = Get+Set under local lock | `SET NX`, atomic across processes; same "key already exists" error |
| `Pull` = Get+Delete under local lock; key survived a failed unmarshal | `GETDEL` (Redis ≥ 6.2), atomic consume; key consumed even if unmarshal fails |

The guarantee is per-key atomicity on a healthy shard, not durability — redis replication is async, so a failover can drop the newest writes. All of this is documented in `doc.go` (new *Atomicity* section) and `MIGRATION.md` (v2.6.0).

## Tests (TDD, red first)

- **Unit** (`atomic_test.go`): the facade routes each op through the capability and never touches `Get`/`Set`/`Delete` on the native path; default-TTL resolution on `Add`; pointer validation before store I/O; error propagation; typed `Pull[T]` composes with the native path.
- **Integration** (`drivers_redis_test.go`, `-tags=integration`, redis 7 from `docker-compose.test.yml`): store-level semantics asserted against redis through an independent go-redis client — TTL preservation, create-without-expiry, `SET NX` exactly-once with TTL, `GETDEL` consume and miss; end-to-end through `contract.Cache` — the rate-limiter pattern (Add-seeded TTL survives increments), 50 concurrent increments land exactly, typed `Pull` consumes exactly once.

## Verification

- `go test -race ./...` — 22 packages ok
- `go test -race -p 1 -tags=integration ./...` — ok against the dockerized redis + mongodb stack
- `go vet ./...` clean; `golangci-lint run` reports only pre-existing findings in `core/http`/`core/job`/`core/lock` tests (untouched by this PR)