### PR TITLE
ci: bump workflow actions to current majors (node24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
 
             -   name: Set up Go
-                uses: actions/setup-go@v5
+                uses: actions/setup-go@v7
                 with:
                     go-version: ${{ matrix.go-version }}
                     cache: true
@@ -55,9 +55,9 @@ jobs:
 
             -   name: Upload coverage to Codecov
                 if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'
-                uses: codecov/codecov-action@v5
+                uses: codecov/codecov-action@v7
                 with:
-                    file: ./coverage.txt
+                    files: ./coverage.txt
                     token: ${{ secrets.CODECOV_TOKEN }}
                     fail_ci_if_error: false
                     handle_no_reports_found: true
@@ -69,16 +69,16 @@ jobs:
     #
     #        steps:
     #            -   name: Checkout code
-    #                uses: actions/checkout@v4
+    #                uses: actions/checkout@v7
     #
     #            -   name: Set up Go
-    #                uses: actions/setup-go@v5
+    #                uses: actions/setup-go@v7
     #                with:
     #                    go-version: ${{ env.GO_VERSION }}
     #                    cache: true
     #
     #            -   name: Run golangci-lint
-    #                uses: golangci/golangci-lint-action@v8
+    #                uses: golangci/golangci-lint-action@v9
     #                with:
     #                    version: latest
     #                    args: --timeout=5m
@@ -89,10 +89,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
 
             -   name: Set up Go
-                uses: actions/setup-go@v5
+                uses: actions/setup-go@v7
                 with:
                     go-version: ${{ env.GO_VERSION }}
                     cache: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,18 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
 
       # Setup Bun
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: bun install
@@ -52,7 +52,7 @@ jobs:
         working-directory: docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Fixes the Node 20 deprecation warning the runners now print for `actions/checkout@v4` and `actions/setup-go@v5` by moving every workflow action to its current major (all node24):

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-go | v5 | v7 |
| codecov/codecov-action | v5 | v7 |
| oven-sh/setup-bun | v1 | v2 |
| actions/configure-pages | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| golangci/golangci-lint-action (commented lint job) | v8 | v9 |

Also renames codecov's long-deprecated `file` input to `files` — v7's action.yml only accepts the latter; `token`, `fail_ci_if_error` and `handle_no_reports_found` are unchanged.

Breaking changes reviewed across the skipped majors:
- **checkout v7** blocks fork-PR checkout only for `pull_request_target`/`workflow_run` events — no workflow here uses those.
- **configure-pages v5**'s break only affected the `static_site_generator: next` input, which this workflow doesn't pass.
- **upload-pages-artifact v4+** stops including dotfiles by default — the VitePress dist contains none.
- **setup-go v6** toolchain-handling change is moot with the explicit `go-version` pin.

CI on this PR exercises checkout/setup-go/codecov directly; the Pages chain runs on merge (deploy-docs triggers on its own file changing).