### PR TITLE
feat(log): native contract-compliant JSON logging

### DIFF
--- a/core/http/accesslog_test.go
+++ b/core/http/accesslog_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.oease.dev/goe/v2/contract"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newAccessLogKernel builds a kernel whose access log writes into an in-memory
+// observer, so tests can assert the exact fields fiberzap emits per request.
+func newAccessLogKernel(t *testing.T) (contract.HTTPKernel, *observer.ObservedLogs) {
+	t.Helper()
+
+	config := &MockConfig{}
+	config.On("GetString", mock.Anything).Return("")
+	config.On("GetBool", mock.Anything).Return(false)
+	config.On("GetInt", mock.Anything).Return(0)
+	config.On("GetStringSlice", mock.Anything).Return([]string{})
+	config.On("GetDuration", mock.Anything).Return(time.Duration(0))
+	config.On("Has", mock.Anything).Return(false)
+
+	core, logs := observer.New(zap.DebugLevel)
+	logger := &MockLogger{}
+	logger.On("Fatal", mock.Anything).Return()
+	logger.On("GetLogger").Return(zap.New(core).Sugar())
+
+	return New(config, logger), logs
+}
+
+func TestAccessLog_ContractFields(t *testing.T) {
+	kernel, logs := newAccessLogKernel(t)
+	app := kernel.App()
+	app.Get("/users/:id", func(c fiber.Ctx) error {
+		return c.SendString("hello!")
+	})
+
+	req := httptest.NewRequest("GET", "/users/42?page=1", nil)
+	req.Host = "api.example.com"
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+	entries := logs.FilterMessage("http request").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+
+	// New contract fields.
+	assert.Equal(t, "/users/:id", fields["route"], "route must be the template, not the concrete URL")
+	assert.Equal(t, "api.example.com", fields["host"])
+	assert.EqualValues(t, len("hello!"), fields["bytesSent"])
+
+	durationMS, ok := fields["duration_ms"].(int64)
+	require.True(t, ok, "duration_ms must be an integer, got %T", fields["duration_ms"])
+	assert.GreaterOrEqual(t, durationMS, int64(0))
+	assert.Less(t, durationMS, int64(60_000), "duration_ms must be measured from the request start, not the zero time")
+
+	// Existing fields must survive.
+	assert.Equal(t, "GET", fields["method"])
+	assert.EqualValues(t, fiber.StatusOK, fields["status"])
+	assert.Contains(t, fields, "latency")
+	assert.Equal(t, "/users/42?page=1", fields["url"])
+	assert.Contains(t, fields, "ip")
+	assert.Contains(t, fields, "request_id")
+}

--- a/core/http/http.go
+++ b/core/http/http.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	fiberzap "github.com/gofiber/contrib/v3/zap"
@@ -108,9 +109,19 @@ func New(config contract.Config, logger contract.Logger, opts ...Option) contrac
 			"/.well-known/health",
 		},
 		Logger: accessLogger.GetLogger().Desugar(),
-		Fields: []string{"method", "status", "latency", "ip", "url"},
+		// route is the matched template (bounded cardinality — the field to
+		// group latency by), host serves per-domain slicing when one app
+		// answers many domains, bytesSent is the response size.
+		Fields: []string{"method", "status", "route", "host", "latency", "ip", "url", "bytesSent"},
 		FieldsFunc: func(c fiber.Ctx) []zap.Field {
-			fields := []zap.Field{zap.String("request_id", requestIDFrom(c, reqIDHeader))}
+			fields := []zap.Field{
+				// The log contract's duration unit is integer milliseconds.
+				// fiberzap's own latency is a human-readable string, and its
+				// timing is not reachable from FieldsFunc — fasthttp's
+				// request-start clock measures the same span.
+				zap.Int64("duration_ms", time.Since(c.RequestCtx().Time()).Milliseconds()),
+				zap.String("request_id", requestIDFrom(c, reqIDHeader)),
+			}
 			if sc := trace.SpanContextFromContext(c.Context()); sc.IsValid() {
 				fields = append(fields, zap.String("trace_id", sc.TraceID().String()))
 			}

--- a/core/log/basefields_test.go
+++ b/core/log/basefields_test.go
@@ -1,0 +1,196 @@
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kvConfig is a map-backed contract.Config for tests that need specific keys.
+type kvConfig map[string]any
+
+func (c kvConfig) Get(key string) any { return c[key] }
+func (c kvConfig) GetString(key string) string {
+	if v, ok := c[key].(string); ok {
+		return v
+	}
+	return ""
+}
+func (c kvConfig) GetInt(key string) int {
+	if v, ok := c[key].(int); ok {
+		return v
+	}
+	return 0
+}
+func (c kvConfig) GetInt64(key string) int64 {
+	if v, ok := c[key].(int64); ok {
+		return v
+	}
+	return 0
+}
+func (c kvConfig) GetFloat64(key string) float64 {
+	if v, ok := c[key].(float64); ok {
+		return v
+	}
+	return 0
+}
+func (c kvConfig) GetBool(key string) bool {
+	if v, ok := c[key].(bool); ok {
+		return v
+	}
+	return false
+}
+func (c kvConfig) GetDuration(key string) time.Duration {
+	if v, ok := c[key].(time.Duration); ok {
+		return v
+	}
+	return 0
+}
+func (c kvConfig) GetStringSlice(key string) []string {
+	if v, ok := c[key].([]string); ok {
+		return v
+	}
+	return nil
+}
+func (c kvConfig) GetStringMap(key string) map[string]any {
+	if v, ok := c[key].(map[string]any); ok {
+		return v
+	}
+	return nil
+}
+func (c kvConfig) Set(key string, value any) { c[key] = value }
+func (c kvConfig) Has(key string) bool {
+	_, ok := c[key]
+	return ok
+}
+func (c kvConfig) All() map[string]any { return c }
+func (c kvConfig) Reload() error       { return nil }
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what fn
+// wrote. Loggers must be constructed inside fn: buildLogger captures the
+// *os.File value at construction time.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	return buf.String()
+}
+
+// lastJSONLine parses the last non-empty line of out as a JSON object.
+func lastJSONLine(t *testing.T, out string) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.NotEmpty(t, lines, "expected at least one log line, got none")
+	last := lines[len(lines)-1]
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(last), &entry), "not a JSON log line: %q", last)
+	return entry
+}
+
+func TestJSONFormat_LowercaseLevel(t *testing.T) {
+	out := captureStdout(t, func() {
+		logger := New(&defaultLoggerConfig{level: "info", format: "json", output: []string{"console"}})
+		logger.Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "info", entry["level"], "JSON logs must carry lowercase levels")
+}
+
+func TestNewModule_JSON_BaseIdentityFields(t *testing.T) {
+	cfg := kvConfig{
+		"LOG_FORMAT":  "json",
+		"APP_NAME":    "orders-api",
+		"APP_VERSION": "1.2.3",
+		"OEASE_ENV":   "prod",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "orders-api", entry["service"])
+	assert.Equal(t, "prod", entry["env"])
+	assert.Equal(t, "1.2.3", entry["version"])
+}
+
+func TestNewModule_JSON_EnvFallsBackToGOEEnv(t *testing.T) {
+	cfg := kvConfig{
+		"LOG_FORMAT": "json",
+		"GOE_ENV":    "staging",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "staging", entry["env"], "env should fall back to GOE_ENV when OEASE_ENV is unset")
+}
+
+func TestNewModule_JSON_EmptyIdentityFieldsOmitted(t *testing.T) {
+	// APP_NAME is set, version and env are not: only service may appear. Unset
+	// identity must be omitted, never emitted as an empty string.
+	cfg := kvConfig{
+		"LOG_FORMAT": "json",
+		"APP_NAME":   "orders-api",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "orders-api", entry["service"])
+	assert.NotContains(t, entry, "env")
+	assert.NotContains(t, entry, "version")
+}
+
+func TestNewModule_TextFormat_NoBaseFields(t *testing.T) {
+	// Base identity fields are for the machine-readable contract; the dev
+	// console stays clean.
+	cfg := kvConfig{
+		"APP_NAME":    "orders-api",
+		"APP_VERSION": "1.2.3",
+		"OEASE_ENV":   "prod",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg).Provide().Info("hello")
+	})
+
+	assert.NotContains(t, out, `"service"`)
+	assert.NotContains(t, out, `"version"`)
+}
+
+func TestNewModule_JSON_FxLoggerCarriesBaseFields(t *testing.T) {
+	cfg := kvConfig{
+		"LOG_FORMAT": "json",
+		"APP_NAME":   "orders-api",
+	}
+
+	out := captureStdout(t, func() {
+		// Fx defaults to warn via defaultModuleLevels, so log at warn.
+		NewModule(cfg).ProvideZap().Warn("fx event")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "orders-api", entry["service"], "the fx logger must inherit base identity fields")
+	assert.Equal(t, "fx", entry["module"])
+}

--- a/core/log/doc.go
+++ b/core/log/doc.go
@@ -1,3 +1,34 @@
 // Package log contains the permanent logging module. It bridges contract.Logger
 // with zap and ensures consistent structured logging across optional modules.
+//
+// # Configuration
+//
+//	LOG_LEVEL=info                  # debug | info | warn | error (default info)
+//	LOG_FORMAT=text                 # text (default) | json; json emits machine-readable lines
+//	LOG_OUTPUT=console              # console (default) and/or file
+//	LOG_CALLER=true                 # annotate lines with file:line
+//	LOG_STACKTRACE=false            # attach stacktraces at error level
+//	LOG_MODULE_LEVELS=job:debug     # per-module level overrides
+//
+// # JSON identity fields
+//
+// With LOG_FORMAT=json every line carries base identity fields resolved once at
+// startup: service from APP_NAME, env from OEASE_ENV (falling back to GOE_ENV)
+// and version from APP_VERSION. Unset values are omitted, and text output stays
+// clean. Code-first configuration wins over the environment:
+//
+//	goe.New(goe.Options{
+//	    Log: []log.Option{
+//	        log.WithVersion(buildinfo.Version),        // ldflags-stamped build version
+//	        log.WithBaseFields("region", "us-east-1"), // extra identity fields
+//	    },
+//	})
+//
+// # Request correlation
+//
+// Logger.WithContext(ctx) enriches a logger from a context.Context: request_id
+// from the fiber requestid middleware (stored into the request context when
+// PassLocalsToContext is on, GOE's default) and trace_id/span_id from an active
+// OpenTelemetry span. Handlers can use http.WithReqCtx(c) directly; WithContext
+// covers service-layer code that only holds a context.
 package log

--- a/core/log/helpers_test.go
+++ b/core/log/helpers_test.go
@@ -144,19 +144,6 @@ func TestConvertFieldsToArgs(t *testing.T) {
 	assert.Equal(t, 42, result[3])
 }
 
-func TestFieldsToArgs(t *testing.T) {
-	fields := []zap.Field{
-		zap.String("key1", "value1"),
-		zap.Int("key2", 123),
-	}
-
-	result := fieldsToArgs(fields)
-
-	assert.Len(t, result, 4)
-	assert.Equal(t, "key1", result[0])
-	assert.Equal(t, "key2", result[2])
-}
-
 func TestConvertArgsToFields(t *testing.T) {
 	t.Run("even number of args", func(t *testing.T) {
 		args := []any{"key1", "value1", "key2", 42}

--- a/core/log/log.go
+++ b/core/log/log.go
@@ -2,12 +2,15 @@ package log
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/gofiber/fiber/v3/middleware/requestid"
 	"go.oease.dev/goe/v2/contract"
 	"go.oease.dev/goe/v2/core/internal/configvalidator"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -75,7 +78,10 @@ func buildLogger(config contract.LoggerConfig, moduleOverrides map[string]zapcor
 	// Create console encoder for text format
 	var encoder zapcore.Encoder
 	if config.Format() == "json" {
-		encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder // No color in JSON
+		// JSON is the machine-readable path; the log contract (and most log
+		// tooling) expects lowercase levels there. Console output keeps the
+		// capitalized/colored levels for humans.
+		encoderConfig.EncodeLevel = zapcore.LowercaseLevelEncoder
 		encoder = zapcore.NewJSONEncoder(encoderConfig)
 	} else {
 		encoder = zapcore.NewConsoleEncoder(encoderConfig)
@@ -244,19 +250,36 @@ func (l *zapLogger) With(keysAndValues ...any) contract.Logger {
 	}
 }
 
-// WithContext creates a new logger with context
+// WithContext returns a request-scoped logger enriched from ctx: request_id
+// from the fiber requestid middleware (which stores into the request context
+// when PassLocalsToContext is on — GOE's default) and, when a valid
+// OpenTelemetry span is present, trace_id/span_id. It gives service-layer code
+// that holds only a context.Context the same correlation fields that
+// http.WithReqCtx provides inside handlers. A context carrying neither returns
+// the receiver unchanged.
 func (l *zapLogger) WithContext(ctx context.Context) contract.Logger {
-	// Extract request ID or trace ID from context if available
-	fields := make([]zap.Field, 0)
+	if ctx == nil {
+		return l
+	}
 
-	// You can extract values from context here
-	// Example: if requestID := ctx.Value("request_id"); requestID != nil {
-	//     fields = append(fields, zap.String("request_id", requestID.(string)))
-	// }
+	fields := make([]zap.Field, 0, 3)
+	if rid := requestid.FromContext(ctx); rid != "" {
+		fields = append(fields, zap.String("request_id", rid))
+	}
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		fields = append(fields,
+			zap.String("trace_id", sc.TraceID().String()),
+			zap.String("span_id", sc.SpanID().String()),
+		)
+	}
+	if len(fields) == 0 {
+		return l
+	}
 
+	logger := l.logger.With(fields...)
 	return &zapLogger{
-		logger: l.logger.With(fields...),
-		sugar:  l.sugar.With(fieldsToArgs(fields)...),
+		logger: logger,
+		sugar:  logger.Sugar(),
 	}
 }
 
@@ -266,15 +289,6 @@ func (l *zapLogger) WithError(err error) contract.Logger {
 		logger: l.logger.With(zap.Error(err)),
 		sugar:  l.sugar.With("error", err),
 	}
-}
-
-// fieldsToArgs converts zap fields to args
-func fieldsToArgs(fields []zap.Field) []any {
-	args := make([]any, 0, len(fields)*2)
-	for _, f := range fields {
-		args = append(args, f.Key, f.Interface)
-	}
-	return args
 }
 
 // convertArgsToFields converts key-value pairs to zap.Field slice
@@ -301,10 +315,27 @@ type Module struct {
 	logger contract.Logger
 	zap    *zap.Logger
 	config contract.Config
+
+	// optErrs holds failures from Option application. They are reported by
+	// ValidateConfig so that startup aborts before the application serves.
+	optErrs []error
 }
 
-// NewModule creates a new log module
-func NewModule(config contract.Config) *Module {
+// NewModule creates a new log module.
+//
+// Configuration resolves in layers: LOG_*/APP_* environment variables first,
+// then opts, so anything set through an Option wins over the environment.
+func NewModule(config contract.Config, opts ...Option) *Module {
+	// Apply code-first options. A failed option applies nothing; its error is
+	// collected and aborts startup through OnStart (and ValidateConfig).
+	var s settings
+	var optErrs []error
+	for _, opt := range opts {
+		if err := opt(&s); err != nil {
+			optErrs = append(optErrs, err)
+		}
+	}
+
 	// Create logger config from app config
 	logConfig := &defaultLoggerConfig{
 		level:      config.GetString("LOG_LEVEL"),
@@ -328,6 +359,17 @@ func NewModule(config contract.Config) *Module {
 	overrides, invalid := parseModuleLevels(config.GetString("LOG_MODULE_LEVELS"))
 	overrides = withDefaultModuleLevels(overrides)
 	logger := buildLogger(logConfig, overrides)
+
+	// Base identity fields (service/env/version, plus WithBaseFields extras)
+	// are stamped once at construction so every JSON line carries them,
+	// including the fx logger derived below. Text output is for humans and
+	// stays clean.
+	if logConfig.format == "json" {
+		base := append(baseIdentityFields(config, s.version), s.baseFields...)
+		if len(base) > 0 {
+			logger = logger.With(base...)
+		}
+	}
 	if len(invalid) > 0 {
 		logger.With(moduleFieldKey, "log").Warn(
 			"Ignored invalid LOG_MODULE_LEVELS entries",
@@ -340,10 +382,39 @@ func NewModule(config contract.Config) *Module {
 	zapLogger := logger.(*zapLogger).logger.With(zap.String(moduleFieldKey, fxModuleName))
 
 	return &Module{
-		logger: logger,
-		zap:    zapLogger,
-		config: config,
+		logger:  logger,
+		zap:     zapLogger,
+		config:  config,
+		optErrs: optErrs,
 	}
+}
+
+// baseIdentityFields resolves the identity fields stamped on every JSON log
+// line: service ← APP_NAME, env ← OEASE_ENV (falling back to GOE_ENV),
+// version ← versionOverride (from WithVersion) falling back to APP_VERSION.
+// Unset values are omitted rather than emitted empty — the log pipeline owns
+// service/env from deployment metadata, but version can only come from the
+// process.
+func baseIdentityFields(config contract.Config, versionOverride string) []any {
+	kv := make([]any, 0, 6)
+	if service := config.GetString("APP_NAME"); service != "" {
+		kv = append(kv, "service", service)
+	}
+	env := config.GetString("OEASE_ENV")
+	if env == "" {
+		env = config.GetString("GOE_ENV")
+	}
+	if env != "" {
+		kv = append(kv, "env", env)
+	}
+	version := versionOverride
+	if version == "" {
+		version = config.GetString("APP_VERSION")
+	}
+	if version != "" {
+		kv = append(kv, "version", version)
+	}
+	return kv
 }
 
 // Name returns the module name
@@ -353,6 +424,14 @@ func (m *Module) Name() string {
 
 // OnStart is called when the module starts
 func (m *Module) OnStart(ctx context.Context) error {
+	// Built-in modules are not registered with the startup validator, so a
+	// failed Option aborts startup here — the job module follows the same
+	// pattern. Bootstrap logging has already worked on the environment-only
+	// configuration, so the operator sees these errors on a working logger.
+	if len(m.optErrs) > 0 {
+		return errors.Join(m.optErrs...)
+	}
+
 	m.logger.With(moduleFieldKey, "log").Info("Log module started")
 	return nil
 }
@@ -377,6 +456,12 @@ func (m *Module) ProvideZap() *zap.Logger {
 
 // ValidateConfig validates the log module configuration
 func (m *Module) ValidateConfig() error {
+	// Option failures are reported first and abort startup, mirroring the
+	// http module's handling of its Options.
+	if len(m.optErrs) > 0 {
+		return errors.Join(m.optErrs...)
+	}
+
 	v := configvalidator.NewConfigValidator(m.config, "log")
 
 	// Log level validation
@@ -386,9 +471,10 @@ func (m *Module) ValidateConfig() error {
 		v.Optional("LOG_LEVEL", "Log level", configvalidator.ValidateOneOf(validLevels...))
 	}
 
-	// Log format validation
+	// Log format validation. "text" is the module's own default; "console" is
+	// accepted as its historical alias.
 	if m.config.Has("LOG_FORMAT") {
-		validFormats := []string{"json", "console"}
+		validFormats := []string{"json", "text", "console"}
 		v.Optional("LOG_FORMAT", "Log format", configvalidator.ValidateOneOf(validFormats...))
 	}
 

--- a/core/log/options.go
+++ b/core/log/options.go
@@ -1,0 +1,56 @@
+package log
+
+import "fmt"
+
+// Option configures the log module from Go code instead of environment
+// variables. Options are applied after the environment, so anything set here
+// wins over the matching APP_* value while the environment still supplies
+// everything left unset.
+//
+// An option that fails records its error and applies nothing; ValidateConfig
+// reports the failure so startup aborts before the application serves.
+type Option func(*settings) error
+
+// settings holds the code-first configuration collected from Options.
+type settings struct {
+	// version overrides the APP_VERSION-derived version base field.
+	version string
+	// baseFields holds extra key/value pairs stamped alongside the identity
+	// fields on every JSON log line. Keys are validated to be strings.
+	baseFields []any
+}
+
+// WithVersion sets the version base field stamped on every JSON log line,
+// winning over APP_VERSION. Use it to carry an ldflags-stamped build version
+// without environment plumbing:
+//
+//	goe.New(goe.Options{
+//	    Log: []log.Option{log.WithVersion(buildinfo.Version)},
+//	})
+//
+// An empty value is ignored, so passing a never-stamped ldflags variable keeps
+// the APP_VERSION fallback.
+func WithVersion(version string) Option {
+	return func(s *settings) error {
+		s.version = version
+		return nil
+	}
+}
+
+// WithBaseFields adds key/value pairs to the base fields stamped on every JSON
+// log line, alongside service/env/version. Keys must be strings and arguments
+// must come in pairs; anything else fails startup via ValidateConfig.
+func WithBaseFields(keysAndValues ...any) Option {
+	return func(s *settings) error {
+		if len(keysAndValues)%2 != 0 {
+			return fmt.Errorf("log.WithBaseFields: odd number of arguments (%d), want key/value pairs", len(keysAndValues))
+		}
+		for i := 0; i < len(keysAndValues); i += 2 {
+			if _, ok := keysAndValues[i].(string); !ok {
+				return fmt.Errorf("log.WithBaseFields: key at index %d is %T, want string", i, keysAndValues[i])
+			}
+		}
+		s.baseFields = append(s.baseFields, keysAndValues...)
+		return nil
+	}
+}

--- a/core/log/options_test.go
+++ b/core/log/options_test.go
@@ -1,0 +1,104 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithVersion_WinsOverAppVersion(t *testing.T) {
+	cfg := kvConfig{
+		"LOG_FORMAT":  "json",
+		"APP_VERSION": "1.0.0",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg, WithVersion("9.9.9+ldflags")).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "9.9.9+ldflags", entry["version"], "a code-first version must win over APP_VERSION")
+}
+
+func TestWithVersion_EmptyFallsBackToAppVersion(t *testing.T) {
+	cfg := kvConfig{
+		"LOG_FORMAT":  "json",
+		"APP_VERSION": "1.0.0",
+	}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg, WithVersion("")).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "1.0.0", entry["version"], "an empty WithVersion must not mask APP_VERSION")
+}
+
+func TestWithBaseFields_AddsPairs(t *testing.T) {
+	cfg := kvConfig{"LOG_FORMAT": "json"}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg, WithBaseFields("region", "us-east-1", "team", "payments")).Provide().Info("hello")
+	})
+
+	entry := lastJSONLine(t, out)
+	assert.Equal(t, "us-east-1", entry["region"])
+	assert.Equal(t, "payments", entry["team"])
+}
+
+func TestWithBaseFields_TextFormatSkipped(t *testing.T) {
+	// Base fields follow the same rule as the identity fields: JSON only.
+	cfg := kvConfig{}
+
+	out := captureStdout(t, func() {
+		NewModule(cfg, WithBaseFields("region", "us-east-1")).Provide().Info("hello")
+	})
+
+	assert.NotContains(t, out, "us-east-1")
+}
+
+func TestWithBaseFields_OddCount_FailsValidateConfig(t *testing.T) {
+	module := NewModule(kvConfig{"LOG_FORMAT": "json"}, WithBaseFields("dangling-key"))
+
+	err := module.ValidateConfig()
+	require.Error(t, err, "an odd key/value count must abort startup")
+	assert.Contains(t, err.Error(), "WithBaseFields")
+}
+
+func TestWithBaseFields_NonStringKey_FailsValidateConfig(t *testing.T) {
+	module := NewModule(kvConfig{"LOG_FORMAT": "json"}, WithBaseFields(42, "value"))
+
+	err := module.ValidateConfig()
+	require.Error(t, err, "a non-string key must abort startup")
+	assert.Contains(t, err.Error(), "WithBaseFields")
+}
+
+func TestOptions_ValidateConfigStillValidatesEnv(t *testing.T) {
+	// Option errors must not mask the existing env validation, and vice versa:
+	// a bad LOG_LEVEL still fails with no options involved.
+	module := NewModule(kvConfig{"LOG_LEVEL": "loud"})
+
+	err := module.ValidateConfig()
+	require.Error(t, err)
+}
+
+func TestOptionErrors_AbortOnStart(t *testing.T) {
+	// Built-in modules are not registered with the startup validator, so
+	// OnStart is where a bad option must abort the application (the job
+	// module follows the same pattern).
+	module := NewModule(kvConfig{}, WithBaseFields("dangling-key"))
+
+	err := module.OnStart(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithBaseFields")
+}
+
+func TestValidateConfig_AcceptsTextFormat(t *testing.T) {
+	// "text" is the module's own default format; the validator must not
+	// reject it.
+	module := NewModule(kvConfig{"LOG_FORMAT": "text"})
+
+	assert.NoError(t, module.ValidateConfig())
+}

--- a/core/log/withcontext_test.go
+++ b/core/log/withcontext_test.go
@@ -1,0 +1,107 @@
+package log
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/requestid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestWithContext_RequestID(t *testing.T) {
+	logger, logs := newObservedLogger(zapcore.DebugLevel, nil)
+
+	// The same setup GOE's http kernel uses: requestid middleware storing into
+	// the request context via PassLocalsToContext.
+	app := fiber.New(fiber.Config{PassLocalsToContext: true})
+	app.Use(requestid.New())
+	app.Get("/", func(c fiber.Ctx) error {
+		// Service-layer shape: only a context.Context crosses the boundary.
+		logInService(c.Context(), logger)
+		return nil
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(fiber.HeaderXRequestID, "req-42")
+	_, err := app.Test(req)
+	require.NoError(t, err)
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "req-42", fields["request_id"])
+}
+
+// logInService stands in for service-layer code that holds only a
+// context.Context, not the fiber ctx.
+func logInService(ctx context.Context, logger *zapLogger) {
+	logger.WithContext(ctx).Info("from the service layer")
+}
+
+func TestWithContext_TraceAndSpan(t *testing.T) {
+	logger, logs := newObservedLogger(zapcore.DebugLevel, nil)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     trace.SpanID{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	logger.WithContext(ctx).Info("with span")
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, sc.TraceID().String(), fields["trace_id"])
+	assert.Equal(t, sc.SpanID().String(), fields["span_id"])
+}
+
+func TestWithContext_SugaredPathCarriesFields(t *testing.T) {
+	// The derived logger's sugared side must carry the fields too — Infow goes
+	// through the sugar, not the structured logger.
+	logger, logs := newObservedLogger(zapcore.DebugLevel, nil)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{0xff, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     trace.SpanID{0xfa, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11},
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	logger.WithContext(ctx).Infow("sugared", "extra", "kv")
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.Equal(t, sc.TraceID().String(), fields["trace_id"])
+	assert.Equal(t, "kv", fields["extra"])
+}
+
+func TestWithContext_EmptyContext_NoFields(t *testing.T) {
+	logger, logs := newObservedLogger(zapcore.DebugLevel, nil)
+
+	logger.WithContext(context.Background()).Info("plain")
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	assert.NotContains(t, fields, "request_id")
+	assert.NotContains(t, fields, "trace_id")
+	assert.NotContains(t, fields, "span_id")
+}
+
+func TestWithContext_NilContext_DoesNotPanic(t *testing.T) {
+	logger, logs := newObservedLogger(zapcore.DebugLevel, nil)
+
+	assert.NotPanics(t, func() {
+		//nolint:staticcheck // deliberately exercising the nil-context guard
+		logger.WithContext(nil).Info("nil ctx")
+	})
+	assert.Equal(t, 1, logs.Len())
+}

--- a/goe.go
+++ b/goe.go
@@ -68,6 +68,7 @@ func New(opts ...Options) contract.Application {
 		opt.WithMetrics = o.WithMetrics
 		opt.WithOTel = o.WithOTel
 		opt.HTTP = o.HTTP
+		opt.Log = o.Log
 		opt.Cache = o.Cache
 		opt.Job = o.Job
 		opt.Lock = o.Lock
@@ -311,7 +312,7 @@ func buildCore(opt Options) (contract.Application, contract.Config, contract.Log
 	instance.app = app.New(appName, appVersion, environment)
 
 	// Create log module
-	logModule := log.NewModule(instance.config)
+	logModule := log.NewModule(instance.config, opt.Log...)
 	instance.logger = logModule.Provide()
 
 	// Build Fx options

--- a/log_options_test.go
+++ b/log_options_test.go
@@ -1,0 +1,61 @@
+package goe
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"go.oease.dev/goe/v2/core/log"
+)
+
+// TestOptions_LogCodeFirst_VersionWired proves Options.Log survives the option
+// merge in New and reaches log.NewModule: a WithVersion option must show up as
+// the version base field on JSON log lines.
+func TestOptions_LogCodeFirst_VersionWired(t *testing.T) {
+	// The logger captures os.Stdout at construction, so the pipe must be in
+	// place before New runs.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	_ = New(Options{
+		Log:             []log.Option{log.WithVersion("wired-9.9.9")},
+		ConfigOverrides: map[string]any{"LOG_FORMAT": "json"},
+	})
+	Log().Info("wiring probe")
+
+	os.Stdout = old
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	// Clean up the singleton like the other root tests.
+	instance.app = nil
+	instance.config = nil
+	instance.logger = nil
+	instance.http = nil
+
+	var probe map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		if json.Unmarshal([]byte(line), &entry) != nil {
+			continue
+		}
+		if entry["msg"] == "wiring probe" {
+			probe = entry
+			break
+		}
+	}
+	if probe == nil {
+		t.Fatalf("wiring probe line not found in output:\n%s", buf.String())
+	}
+	if got := probe["version"]; got != "wired-9.9.9" {
+		t.Errorf("version = %v, want wired-9.9.9 (Options.Log not wired through)", got)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 	"go.oease.dev/goe/v2/core/http"
 	"go.oease.dev/goe/v2/core/job"
 	"go.oease.dev/goe/v2/core/lock"
+	"go.oease.dev/goe/v2/core/log"
 	"go.oease.dev/goe/v2/core/mongodb"
 	"go.oease.dev/goe/v2/core/mongodb/migrate"
 )
@@ -46,6 +47,20 @@ type Options struct {
 	//
 	// See the core/http package for the full option list.
 	HTTP []http.Option
+
+	// Log configures the log module from Go code. The log module is always
+	// enabled, so unlike the other module option slices this implies nothing.
+	//
+	// Options are applied after the environment, so anything set here wins
+	// over the matching APP_* variable. The main use is carrying an
+	// ldflags-stamped build version onto every JSON log line:
+	//
+	//	goe.New(goe.Options{
+	//	    Log: []log.Option{log.WithVersion(buildinfo.Version)},
+	//	})
+	//
+	// See the core/log package for the full option list.
+	Log []log.Option
 
 	// Cache configures the cache module from Go code instead of environment
 	// variables. A non-nil value implies WithCache, so the module does not


### PR DESCRIPTION
Closes #115.

Makes GOE emit the platform log contract natively, so `docker logs` output is contract-true for every GOE app without a collector normalizing in between. Verified end-to-end: a real app booted with `LOG_FORMAT=json` now emits

```json
{"level":"info","timestamp":"...","msg":"http request","service":"hello-svc","env":"prod","version":"2.7.0-test","module":"access","duration_ms":0,"request_id":"e2e-req-1","method":"GET","status":200,"route":"/hello/:name","host":"127.0.0.1","latency":"162.208µs","ip":"127.0.0.1","url":"/hello/world","bytesSent":13}
```

### 1. Lowercase `level` in JSON mode
The JSON encoder branch now uses `LowercaseLevelEncoder`. Console output (dev and prod-text) keeps the capitalized/colored levels for humans.

### 2. Base identity fields: `service`, `env`, `version` (JSON mode only)
Stamped once at `log.NewModule` so every JSON line — including the fx logger's — carries them: `service` ← `APP_NAME`, `env` ← `OEASE_ENV` (fallback `GOE_ENV`), `version` ← `APP_VERSION`. Unset values are omitted rather than emitted empty (the pipeline owns `service`/`env` from deployment metadata; `version` is the field only the process can supply). Text output stays clean for dev terminals.

Code-first configuration follows the established module-options pattern with a new `goe.Options.Log`:

```go
goe.New(goe.Options{
    Log: []log.Option{
        log.WithVersion(buildinfo.Version),        // ldflags-stamped, wins over APP_VERSION
        log.WithBaseFields("region", "us-east-1"), // extra identity pairs
    },
})
```

`ConfigOverrides{"APP_VERSION": ...}` also still works since overrides wrap the config before the log module reads it. Invalid options (odd pair count, non-string key) abort startup via `OnStart` — mirroring the job module, because built-in modules are never registered with the startup validator, so `ValidateConfig` alone would never run on the real path.

### 3. Access log: `route`, `host`, `bytesSent`, `duration_ms`
- `route` — the matched template (`/hello/:name`): bounded cardinality, the field to group latency by.
- `host` — per-domain slicing when one app serves many domains.
- `bytesSent` — response size.
- `duration_ms` — integer milliseconds via `FieldsFunc`. Note: the issue's `MillisDurationEncoder` alternative is moot on contrib/zap v1.0.10 — its `latency` is a pre-formatted **string** (`"162.208µs"`), not a `zap.Duration`, and its internal timing is unreachable from `FieldsFunc`. `duration_ms` is measured from fasthttp's request-start clock (`c.RequestCtx().Time()`), which spans the same work with no extra middleware. `latency` is kept alongside for existing consumers.

### 4. `WithContext` implemented
`Logger.WithContext(ctx)` now extracts `request_id` (fiber v3 `requestid.FromContext` accepts a plain `context.Context`; the middleware stores into the request context because GOE defaults `PassLocalsToContext: true`) and `trace_id`/`span_id` from an active OTel span. Service-layer code holding only a `context.Context` gets the same correlation fields `http.WithReqCtx` gives handlers. A context carrying neither returns the receiver unchanged.

### 5. Key renames — declined
`timestamp`→`time` / `stacktrace`→`stack` / `error`→`err` are cosmetic-with-breakage and the pipeline already normalizes the aliases, per the issue's own framing.

### Incidental fixes
- Removed the dead `fieldsToArgs` helper — its `f.Interface` read silently yielded `nil` for typed fields (its test only asserted keys, never values).
- The `LOG_FORMAT` validator now accepts `text`, the module's own documented default (previously only `json`/`console` — dead code today, but a landmine for whenever validation runs).

### Testing
TDD throughout (every behavior red first). New coverage: JSON lowercase level; identity-field presence/omission/fallbacks; `WithVersion` precedence incl. empty-value fallback; `WithBaseFields` happy path, text-mode skip, and both error shapes aborting `OnStart`/`ValidateConfig`; `WithContext` request-id through a real fiber app + requestid middleware, OTel span extraction, sugared-path fields, empty/nil-context guards; access-log contract fields through the real kernel middleware stack with an observed logger; root-level test proving `Options.Log` survives the option merge in `goe.New`. Full suite: `go test -race ./...` — 22 packages ok, no data races; `go vet ./...` clean.

No breaking API changes: `log.NewModule` gained a variadic parameter only, and all existing log fields/keys are preserved.